### PR TITLE
support kubernetes v1.11- for resource reservations

### DIFF
--- a/pkg/apis/sparkscheduler/v1beta1/crd.go
+++ b/pkg/apis/sparkscheduler/v1beta1/crd.go
@@ -26,7 +26,8 @@ var resourceReservationDefinition = &apiextensionsv1beta1.CustomResourceDefiniti
 		Name: resourceReservationCRDName,
 	},
 	Spec: apiextensionsv1beta1.CustomResourceDefinitionSpec{
-		Group: GroupName,
+		Group:   GroupName,
+		Version: "v1beta1",
 		Versions: []apiextensionsv1beta1.CustomResourceDefinitionVersion{
 			{
 				Name:    "v1beta1",


### PR DESCRIPTION
Kubernetes v1.11+ use the Versions slice and only default to Version if the slice is empty