### PR TITLE
Binpack function to allocate application in a single zone when possible

### DIFF
--- a/pkg/binpack/az_aware_pack_tightly.go
+++ b/pkg/binpack/az_aware_pack_tightly.go
@@ -1,0 +1,61 @@
+// Copyright (c) 2019 Palantir Technologies. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package binpack
+
+import (
+	"context"
+
+	"github.com/palantir/k8s-spark-scheduler-lib/pkg/resources"
+)
+
+// AzAwareTightlyPack is a SparkBinPackFunction that tries to put the driver pod
+// to as prior nodes as possible before trying to tightly pack executors
+// while also trying to ensure that we can fit everything in a single AZ.
+// If it cannot fit into a single AZ it falls back to the TightlyPack SparkBinPackFunction.
+var AzAwareTightlyPack = SparkBinPackFunction(func(
+	ctx context.Context,
+	driverResources, executorResources *resources.Resources,
+	executorCount int,
+	driverNodePriorityOrder, executorNodePriorityOrder []string,
+	nodeZoneLabels map[string]string,
+	availableResources resources.NodeGroupResources) (string, []string, bool) {
+
+	driverNodePriorityOrderByZone := groupNodesByZone(driverNodePriorityOrder, nodeZoneLabels)
+	executorNodePriorityOrderByZone := groupNodesByZone(executorNodePriorityOrder, nodeZoneLabels)
+
+	for zone, driverNodePriorityOrderForZone := range driverNodePriorityOrderByZone {
+		executorNodePriorityOrderForZone, ok := executorNodePriorityOrderByZone[zone]
+		if !ok {
+			continue
+		}
+		driverNode, executorNodes, hasCapacity := SparkBinPack(ctx, driverResources, executorResources, executorCount, driverNodePriorityOrderForZone, executorNodePriorityOrderForZone, availableResources, tightlyPackExecutors)
+		if hasCapacity {
+			return driverNode, executorNodes, hasCapacity
+		}
+	}
+	return SparkBinPack(ctx, driverResources, executorResources, executorCount, driverNodePriorityOrder, executorNodePriorityOrder, availableResources, tightlyPackExecutors)
+})
+
+func groupNodesByZone(nodeNames []string, nodeZoneLabels map[string]string) map[string][]string {
+	nodeNamesByZone := make(map[string][]string)
+	for _, nodeName := range nodeNames {
+		zone, ok := nodeZoneLabels[nodeName]
+		if !ok {
+			zone = "unknown"
+		}
+		nodeNamesByZone[zone] = append(nodeNamesByZone[zone], nodeName)
+	}
+	return nodeNamesByZone
+}

--- a/pkg/binpack/binpack.go
+++ b/pkg/binpack/binpack.go
@@ -26,6 +26,7 @@ type SparkBinPackFunction func(
 	driverResources, executorResources *resources.Resources,
 	executorCount int,
 	driverNodePriorityOrder, executorNodePriorityOrder []string,
+	nodeZoneLabels map[string]string,
 	availableResources resources.NodeGroupResources) (driverNode string, executorNodes []string, hasCapacity bool)
 
 // GenericBinPackFunction is a function type for assigning nodes to a batch of equivalent pods

--- a/pkg/binpack/binpack.go
+++ b/pkg/binpack/binpack.go
@@ -47,11 +47,7 @@ func SparkBinPack(
 	distributeExecutors GenericBinPackFunction) (driverNode string, executorNodes []string, hasCapacity bool) {
 	for _, name := range driverNodePriorityOrder {
 		nodeSchedulingMetadata, ok := nodesSchedulingMetadata[name]
-		if !ok {
-			continue
-		}
-
-		if driverResources.GreaterThan(nodeSchedulingMetadata.AvailableResources) {
+		if !ok || driverResources.GreaterThan(nodeSchedulingMetadata.AvailableResources) {
 			continue
 		}
 		reserved := make(resources.NodeGroupResources, len(nodesSchedulingMetadata))

--- a/pkg/binpack/binpack.go
+++ b/pkg/binpack/binpack.go
@@ -26,8 +26,7 @@ type SparkBinPackFunction func(
 	driverResources, executorResources *resources.Resources,
 	executorCount int,
 	driverNodePriorityOrder, executorNodePriorityOrder []string,
-	nodeZoneLabels map[string]string,
-	availableResources resources.NodeGroupResources) (driverNode string, executorNodes []string, hasCapacity bool)
+	nodesSchedulingMetadata resources.NodeGroupSchedulingMetadata) (driverNode string, executorNodes []string, hasCapacity bool)
 
 // GenericBinPackFunction is a function type for assigning nodes to a batch of equivalent pods
 type GenericBinPackFunction func(
@@ -35,7 +34,8 @@ type GenericBinPackFunction func(
 	itemResources *resources.Resources,
 	itemCount int,
 	nodePriorityOrder []string,
-	availableResources, reserved resources.NodeGroupResources) (nodes []string, hasCapacity bool)
+	nodesSchedulingMetadata resources.NodeGroupSchedulingMetadata,
+	reservedResources resources.NodeGroupResources) (nodes []string, hasCapacity bool)
 
 // SparkBinPack places the driver first and calls distributeExecutors function to place executors
 func SparkBinPack(
@@ -43,16 +43,21 @@ func SparkBinPack(
 	driverResources, executorResources *resources.Resources,
 	executorCount int,
 	driverNodePriorityOrder, executorNodePriorityOrder []string,
-	availableResources resources.NodeGroupResources,
+	nodesSchedulingMetadata resources.NodeGroupSchedulingMetadata,
 	distributeExecutors GenericBinPackFunction) (driverNode string, executorNodes []string, hasCapacity bool) {
 	for _, name := range driverNodePriorityOrder {
-		if driverResources.GreaterThan(availableResources[name]) {
+		nodeSchedulingMetadata, ok := nodesSchedulingMetadata[name]
+		if !ok {
 			continue
 		}
-		reserved := make(resources.NodeGroupResources, len(availableResources))
+
+		if driverResources.GreaterThan(nodeSchedulingMetadata.AvailableResources) {
+			continue
+		}
+		reserved := make(resources.NodeGroupResources, len(nodesSchedulingMetadata))
 		reserved[name] = driverResources.Copy()
 		executorNodes, ok := distributeExecutors(
-			ctx, executorResources, executorCount, executorNodePriorityOrder, availableResources, reserved)
+			ctx, executorResources, executorCount, executorNodePriorityOrder, nodesSchedulingMetadata, reserved)
 		if ok {
 			return name, executorNodes, true
 		}

--- a/pkg/binpack/distribute_evenly.go
+++ b/pkg/binpack/distribute_evenly.go
@@ -27,6 +27,7 @@ var DistributeEvenly = SparkBinPackFunction(func(
 	driverResources, executorResources *resources.Resources,
 	executorCount int,
 	driverNodePriorityOrder, executorNodePriorityOrder []string,
+	nodeZoneLabels map[string]string,
 	availableResources resources.NodeGroupResources) (string, []string, bool) {
 	return SparkBinPack(ctx, driverResources, executorResources, executorCount, driverNodePriorityOrder, executorNodePriorityOrder, availableResources, distributeExecutorsEvenly)
 })

--- a/pkg/binpack/distribute_evenly.go
+++ b/pkg/binpack/distribute_evenly.go
@@ -27,9 +27,8 @@ var DistributeEvenly = SparkBinPackFunction(func(
 	driverResources, executorResources *resources.Resources,
 	executorCount int,
 	driverNodePriorityOrder, executorNodePriorityOrder []string,
-	nodeZoneLabels map[string]string,
-	availableResources resources.NodeGroupResources) (string, []string, bool) {
-	return SparkBinPack(ctx, driverResources, executorResources, executorCount, driverNodePriorityOrder, executorNodePriorityOrder, availableResources, distributeExecutorsEvenly)
+	nodesSchedulingMetadata resources.NodeGroupSchedulingMetadata) (string, []string, bool) {
+	return SparkBinPack(ctx, driverResources, executorResources, executorCount, driverNodePriorityOrder, executorNodePriorityOrder, nodesSchedulingMetadata, distributeExecutorsEvenly)
 })
 
 func distributeExecutorsEvenly(
@@ -37,7 +36,8 @@ func distributeExecutorsEvenly(
 	executorResources *resources.Resources,
 	executorCount int,
 	nodePriorityOrder []string,
-	availableResources, reserved resources.NodeGroupResources) ([]string, bool) {
+	nodesSchedulingMetadata resources.NodeGroupSchedulingMetadata,
+	reservedResources resources.NodeGroupResources) ([]string, bool) {
 	availableNodes := make(map[string]bool, len(nodePriorityOrder))
 	for _, name := range nodePriorityOrder {
 		availableNodes[name] = true
@@ -52,11 +52,12 @@ func distributeExecutorsEvenly(
 				continue
 			}
 
-			if reserved[n] == nil {
-				reserved[n] = resources.Zero()
+			if reservedResources[n] == nil {
+				reservedResources[n] = resources.Zero()
 			}
-			reserved[n].Add(executorResources)
-			if reserved[n].GreaterThan(availableResources[n]) {
+			reservedResources[n].Add(executorResources)
+			nodeSchedulingMetadata, ok := nodesSchedulingMetadata[n]
+			if !ok || reservedResources[n].GreaterThan(nodeSchedulingMetadata.AvailableResources) {
 				// can not allocate a resource to this node
 				delete(availableNodes, n)
 			} else {

--- a/pkg/binpack/distribute_evenly_test.go
+++ b/pkg/binpack/distribute_evenly_test.go
@@ -37,6 +37,7 @@ func TestDistributeEvenly(t *testing.T) {
 		executorResources  *resources.Resources
 		numExecutors       int
 		availableResources resources.NodeGroupResources
+		nodeZoneLabels     map[string]string
 		nodePriorityOrder  []string
 		expectedDriverNode string
 		willFit            bool
@@ -115,6 +116,7 @@ func TestDistributeEvenly(t *testing.T) {
 				test.numExecutors,
 				test.nodePriorityOrder,
 				test.nodePriorityOrder,
+				test.nodeZoneLabels,
 				test.availableResources)
 			if ok != test.willFit {
 				t.Fatalf("mismatch in willFit, expected: %v, got: %v", test.willFit, ok)

--- a/pkg/binpack/distribute_evenly_test.go
+++ b/pkg/binpack/distribute_evenly_test.go
@@ -29,27 +29,32 @@ func createResources(cpu, memory int64) *resources.Resources {
 		Memory: *resource.NewQuantity(memory, resource.BinarySI),
 	}
 }
+func createSchedulingMetadata(cpu, memory int64, zoneLabel string) *resources.NodeSchedulingMetadata {
+	return &resources.NodeSchedulingMetadata{
+		AvailableResources: createResources(cpu, memory),
+		ZoneLabel: zoneLabel,
+	}
+}
 
 func TestDistributeEvenly(t *testing.T) {
 	tests := []struct {
-		name               string
-		driverResources    *resources.Resources
-		executorResources  *resources.Resources
-		numExecutors       int
-		availableResources resources.NodeGroupResources
-		nodeZoneLabels     map[string]string
-		nodePriorityOrder  []string
-		expectedDriverNode string
-		willFit            bool
-		expectedCounts     map[string]int
+		name                    string
+		driverResources         *resources.Resources
+		executorResources       *resources.Resources
+		numExecutors            int
+		nodesSchedulingMetadata resources.NodeGroupSchedulingMetadata
+		nodePriorityOrder       []string
+		expectedDriverNode      string
+		willFit                 bool
+		expectedCounts          map[string]int
 	}{{
 		name:              "application fits",
 		driverResources:   createResources(1, 3),
 		executorResources: createResources(2, 5),
 		numExecutors:      2,
-		availableResources: resources.NodeGroupResources(map[string]*resources.Resources{
-			"n1": createResources(5, 10),
-			"n2": createResources(4, 5),
+		nodesSchedulingMetadata: resources.NodeGroupSchedulingMetadata(map[string]*resources.NodeSchedulingMetadata{
+			"n1": createSchedulingMetadata(5, 10, "zone1"),
+			"n2": createSchedulingMetadata(4, 5, "zone1"),
 		}),
 		nodePriorityOrder:  []string{"n1", "n2"},
 		expectedDriverNode: "n1",
@@ -60,9 +65,9 @@ func TestDistributeEvenly(t *testing.T) {
 		driverResources:   createResources(2, 4),
 		executorResources: createResources(1, 1),
 		numExecutors:      1,
-		availableResources: map[string]*resources.Resources{
-			"n1": createResources(2, 3),
-		},
+		nodesSchedulingMetadata: resources.NodeGroupSchedulingMetadata(map[string]*resources.NodeSchedulingMetadata{
+			"n1": createSchedulingMetadata(2, 3, "zone1"),
+		}),
 		nodePriorityOrder: []string{"n1"},
 		willFit:           false,
 		expectedCounts:    nil,
@@ -71,11 +76,11 @@ func TestDistributeEvenly(t *testing.T) {
 		driverResources:   createResources(1, 2),
 		executorResources: createResources(1, 1),
 		numExecutors:      40,
-		availableResources: map[string]*resources.Resources{
-			"n1": createResources(13, 14),
-			"n2": createResources(12, 12),
-			"n3": createResources(16, 16),
-		},
+		nodesSchedulingMetadata: resources.NodeGroupSchedulingMetadata(map[string]*resources.NodeSchedulingMetadata{
+			"n1": createSchedulingMetadata(13, 14, "zone1"),
+			"n2": createSchedulingMetadata(12, 12, "zone1"),
+			"n3": createSchedulingMetadata(16, 16, "zone1"),
+		}),
 		nodePriorityOrder:  []string{"n1", "n2", "n3"},
 		expectedDriverNode: "n1",
 		willFit:            true,
@@ -85,9 +90,11 @@ func TestDistributeEvenly(t *testing.T) {
 		driverResources:   createResources(1, 1),
 		executorResources: createResources(1, 2),
 		numExecutors:      8,
-		availableResources: map[string]*resources.Resources{
-			"n1": createResources(8, 20),
-		},
+		nodesSchedulingMetadata: resources.NodeGroupSchedulingMetadata(map[string]*resources.NodeSchedulingMetadata{
+			"n1": {
+				AvailableResources: createResources(8, 20),
+			},
+		}),
 		nodePriorityOrder: []string{"n1"},
 		willFit:           false,
 		expectedCounts:    nil,
@@ -96,11 +103,11 @@ func TestDistributeEvenly(t *testing.T) {
 		driverResources:   createResources(1, 2),
 		executorResources: createResources(2, 3),
 		numExecutors:      2,
-		availableResources: map[string]*resources.Resources{
-			"n1": createResources(8, 20),
-			"n2": createResources(8, 20),
-			"n3": createResources(8, 20),
-		},
+		nodesSchedulingMetadata: resources.NodeGroupSchedulingMetadata(map[string]*resources.NodeSchedulingMetadata{
+			"n1": createSchedulingMetadata(8, 20, "zone1"),
+			"n2": createSchedulingMetadata(8, 20, "zone1"),
+			"n3": createSchedulingMetadata(8, 20, "zone1"),
+		}),
 		nodePriorityOrder:  []string{"n1", "n2", "n3"},
 		expectedDriverNode: "n1",
 		willFit:            true,
@@ -116,8 +123,7 @@ func TestDistributeEvenly(t *testing.T) {
 				test.numExecutors,
 				test.nodePriorityOrder,
 				test.nodePriorityOrder,
-				test.nodeZoneLabels,
-				test.availableResources)
+				test.nodesSchedulingMetadata)
 			if ok != test.willFit {
 				t.Fatalf("mismatch in willFit, expected: %v, got: %v", test.willFit, ok)
 			}

--- a/pkg/binpack/distribute_evenly_test.go
+++ b/pkg/binpack/distribute_evenly_test.go
@@ -32,7 +32,7 @@ func createResources(cpu, memory int64) *resources.Resources {
 func createSchedulingMetadata(cpu, memory int64, zoneLabel string) *resources.NodeSchedulingMetadata {
 	return &resources.NodeSchedulingMetadata{
 		AvailableResources: createResources(cpu, memory),
-		ZoneLabel: zoneLabel,
+		ZoneLabel:          zoneLabel,
 	}
 }
 

--- a/pkg/binpack/pack_tightly.go
+++ b/pkg/binpack/pack_tightly.go
@@ -27,6 +27,7 @@ var TightlyPack = SparkBinPackFunction(func(
 	driverResources, executorResources *resources.Resources,
 	executorCount int,
 	driverNodePriorityOrder, executorNodePriorityOrder []string,
+	nodeZoneLabels map[string]string,
 	availableResources resources.NodeGroupResources) (string, []string, bool) {
 	return SparkBinPack(ctx, driverResources, executorResources, executorCount, driverNodePriorityOrder, executorNodePriorityOrder, availableResources, tightlyPackExecutors)
 })

--- a/pkg/binpack/pack_tightly.go
+++ b/pkg/binpack/pack_tightly.go
@@ -27,9 +27,8 @@ var TightlyPack = SparkBinPackFunction(func(
 	driverResources, executorResources *resources.Resources,
 	executorCount int,
 	driverNodePriorityOrder, executorNodePriorityOrder []string,
-	nodeZoneLabels map[string]string,
-	availableResources resources.NodeGroupResources) (string, []string, bool) {
-	return SparkBinPack(ctx, driverResources, executorResources, executorCount, driverNodePriorityOrder, executorNodePriorityOrder, availableResources, tightlyPackExecutors)
+	nodesSchedulingMetadata resources.NodeGroupSchedulingMetadata) (string, []string, bool) {
+	return SparkBinPack(ctx, driverResources, executorResources, executorCount, driverNodePriorityOrder, executorNodePriorityOrder, nodesSchedulingMetadata, tightlyPackExecutors)
 })
 
 func tightlyPackExecutors(
@@ -37,18 +36,23 @@ func tightlyPackExecutors(
 	executorResources *resources.Resources,
 	executorCount int,
 	nodePriorityOrder []string,
-	availableResources, reserved resources.NodeGroupResources) ([]string, bool) {
+	nodesSchedulingMetadata resources.NodeGroupSchedulingMetadata,
+	reservedResources resources.NodeGroupResources) ([]string, bool) {
 	executorNodes := make([]string, 0, executorCount)
 	if executorCount == 0 {
 		return executorNodes, true
 	}
 	for _, n := range nodePriorityOrder {
-		if reserved[n] == nil {
-			reserved[n] = resources.Zero()
+		if reservedResources[n] == nil {
+			reservedResources[n] = resources.Zero()
 		}
 		for {
-			reserved[n].Add(executorResources)
-			if reserved[n].GreaterThan(availableResources[n]) {
+			reservedResources[n].Add(executorResources)
+			nodeSchedulingMetadata, ok := nodesSchedulingMetadata[n]
+			if !ok {
+				break
+			}
+			if reservedResources[n].GreaterThan(nodeSchedulingMetadata.AvailableResources) {
 				break
 			}
 			executorNodes = append(executorNodes, n)

--- a/pkg/binpack/pack_tightly.go
+++ b/pkg/binpack/pack_tightly.go
@@ -49,10 +49,7 @@ func tightlyPackExecutors(
 		for {
 			reservedResources[n].Add(executorResources)
 			nodeSchedulingMetadata, ok := nodesSchedulingMetadata[n]
-			if !ok {
-				break
-			}
-			if reservedResources[n].GreaterThan(nodeSchedulingMetadata.AvailableResources) {
+			if !ok || reservedResources[n].GreaterThan(nodeSchedulingMetadata.AvailableResources) {
 				break
 			}
 			executorNodes = append(executorNodes, n)

--- a/pkg/binpack/pack_tightly_test.go
+++ b/pkg/binpack/pack_tightly_test.go
@@ -24,24 +24,23 @@ import (
 
 func TestTightlyPack(t *testing.T) {
 	tests := []struct {
-		name               string
-		driverResources    *resources.Resources
-		executorResources  *resources.Resources
-		numExecutors       int
-		availableResources resources.NodeGroupResources
-		nodeZoneLabels     map[string]string
-		nodePriorityOrder  []string
-		expectedDriverNode string
-		willFit            bool
-		expectedCounts     map[string]int
+		name                    string
+		driverResources         *resources.Resources
+		executorResources       *resources.Resources
+		numExecutors            int
+		nodesSchedulingMetadata resources.NodeGroupSchedulingMetadata
+		nodePriorityOrder       []string
+		expectedDriverNode      string
+		willFit                 bool
+		expectedCounts          map[string]int
 	}{{
 		name:              "application fits",
 		driverResources:   createResources(1, 3),
 		executorResources: createResources(2, 5),
 		numExecutors:      2,
-		availableResources: resources.NodeGroupResources(map[string]*resources.Resources{
-			"n1": createResources(5, 10),
-			"n2": createResources(4, 5),
+		nodesSchedulingMetadata: resources.NodeGroupSchedulingMetadata(map[string]*resources.NodeSchedulingMetadata{
+			"n1": createSchedulingMetadata(5, 10, "zone1"),
+			"n2": createSchedulingMetadata(4, 5, "zone1"),
 		}),
 		nodePriorityOrder:  []string{"n1", "n2"},
 		expectedDriverNode: "n1",
@@ -52,9 +51,9 @@ func TestTightlyPack(t *testing.T) {
 		driverResources:   createResources(1, 3),
 		executorResources: createResources(2, 5),
 		numExecutors:      5,
-		availableResources: resources.NodeGroupResources(map[string]*resources.Resources{
-			"n1": createResources(11, 28),
-			"n2": createResources(10, 20),
+		nodesSchedulingMetadata: resources.NodeGroupSchedulingMetadata(map[string]*resources.NodeSchedulingMetadata{
+			"n1": createSchedulingMetadata(11, 28, "zone1"),
+			"n2": createSchedulingMetadata(10, 20, "zone1"),
 		}),
 		nodePriorityOrder:  []string{"n1", "n2"},
 		expectedDriverNode: "n1",
@@ -65,9 +64,9 @@ func TestTightlyPack(t *testing.T) {
 		driverResources:   createResources(2, 4),
 		executorResources: createResources(1, 1),
 		numExecutors:      1,
-		availableResources: map[string]*resources.Resources{
-			"n1": createResources(2, 3),
-		},
+		nodesSchedulingMetadata: resources.NodeGroupSchedulingMetadata(map[string]*resources.NodeSchedulingMetadata{
+			"n1": createSchedulingMetadata(2, 3, "zone1"),
+		}),
 		nodePriorityOrder: []string{"n1"},
 		willFit:           false,
 		expectedCounts:    nil,
@@ -76,11 +75,11 @@ func TestTightlyPack(t *testing.T) {
 		driverResources:   createResources(1, 2),
 		executorResources: createResources(1, 1),
 		numExecutors:      40,
-		availableResources: map[string]*resources.Resources{
-			"n1": createResources(13, 14),
-			"n2": createResources(12, 12),
-			"n3": createResources(16, 16),
-		},
+		nodesSchedulingMetadata: resources.NodeGroupSchedulingMetadata(map[string]*resources.NodeSchedulingMetadata{
+			"n1": createSchedulingMetadata(13, 14, "zone1"),
+			"n2": createSchedulingMetadata(12, 12, "zone1"),
+			"n3": createSchedulingMetadata(16, 16, "zone1"),
+		}),
 		nodePriorityOrder:  []string{"n1", "n2", "n3"},
 		expectedDriverNode: "n1",
 		willFit:            true,
@@ -90,9 +89,9 @@ func TestTightlyPack(t *testing.T) {
 		driverResources:   createResources(1, 1),
 		executorResources: createResources(1, 2),
 		numExecutors:      8,
-		availableResources: map[string]*resources.Resources{
-			"n1": createResources(8, 20),
-		},
+		nodesSchedulingMetadata: resources.NodeGroupSchedulingMetadata(map[string]*resources.NodeSchedulingMetadata{
+			"n1": createSchedulingMetadata(8, 20, "zone1"),
+		}),
 		nodePriorityOrder: []string{"n1"},
 		willFit:           false,
 		expectedCounts:    nil,
@@ -101,11 +100,11 @@ func TestTightlyPack(t *testing.T) {
 		driverResources:   createResources(1, 2),
 		executorResources: createResources(2, 3),
 		numExecutors:      2,
-		availableResources: map[string]*resources.Resources{
-			"n1": createResources(8, 20),
-			"n2": createResources(8, 20),
-			"n3": createResources(8, 20),
-		},
+		nodesSchedulingMetadata: resources.NodeGroupSchedulingMetadata(map[string]*resources.NodeSchedulingMetadata{
+			"n1": createSchedulingMetadata(8, 20, "zone1"),
+			"n2": createSchedulingMetadata(8, 20, "zone1"),
+			"n3": createSchedulingMetadata(8, 20, "zone1"),
+		}),
 		nodePriorityOrder:  []string{"n1", "n2", "n3"},
 		expectedDriverNode: "n1",
 		willFit:            true,
@@ -121,8 +120,7 @@ func TestTightlyPack(t *testing.T) {
 				test.numExecutors,
 				test.nodePriorityOrder,
 				test.nodePriorityOrder,
-				test.nodeZoneLabels,
-				test.availableResources)
+				test.nodesSchedulingMetadata)
 			if ok != test.willFit {
 				t.Fatalf("mismatch in willFit, expected: %v, got: %v", test.willFit, ok)
 			}

--- a/pkg/resources/resources.go
+++ b/pkg/resources/resources.go
@@ -102,8 +102,8 @@ func (nodeResources NodeGroupResources) Sub(other NodeGroupResources) {
 	}
 }
 
-// SubtractUsage subtracts all resources in other from the receiver, modifies receiver
-func (nodesSchedulingMetadata NodeGroupSchedulingMetadata) SubtractUsage(usedResourcesByNodeName NodeGroupResources) {
+// SubtractUsageIfExists subtracts usedResourcesByNodeName from the receiver, modifies receiver, only for nodes that exist in receiver
+func (nodesSchedulingMetadata NodeGroupSchedulingMetadata) SubtractUsageIfExists(usedResourcesByNodeName NodeGroupResources) {
 	for nodeName, usedResources := range usedResourcesByNodeName {
 		if nodeSchedulingMetadata, ok := nodesSchedulingMetadata[nodeName]; ok {
 			nodeSchedulingMetadata.AvailableResources.Sub(usedResources)

--- a/pkg/resources/resources.go
+++ b/pkg/resources/resources.go
@@ -68,8 +68,8 @@ func NodeSchedulingMetadataForNodes(nodes []*v1.Node, currentUsage NodeGroupReso
 		nodeGroupSchedulingMetadata[node.Name] = &NodeSchedulingMetadata{
 			AvailableResources: subtractFromResourceList(node.Status.Allocatable, currentUsageForNode),
 			CreationTimestamp:  node.CreationTimestamp.Time,
-			ZoneLabel: zoneLabel,
-			Unschedulable: node.Spec.Unschedulable,
+			ZoneLabel:          zoneLabel,
+			Unschedulable:      node.Spec.Unschedulable,
 		}
 	}
 	return nodeGroupSchedulingMetadata

--- a/pkg/resources/resources.go
+++ b/pkg/resources/resources.go
@@ -15,10 +15,11 @@
 package resources
 
 import (
+	"time"
+
 	"github.com/palantir/k8s-spark-scheduler-lib/pkg/apis/sparkscheduler/v1beta1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
-	"time"
 )
 
 const (
@@ -78,7 +79,7 @@ func NodeSchedulingMetadataForNodes(nodes []*v1.Node, currentUsage NodeGroupReso
 // NodeGroupResources represents resources for a group of nodes
 type NodeGroupResources map[string]*Resources
 
-// NodeGroupSchedulingMetadata represents SchedulingMetadata for a group of nodes
+// NodeGroupSchedulingMetadata represents NodeSchedulingMetadata for a group of nodes
 type NodeGroupSchedulingMetadata map[string]*NodeSchedulingMetadata
 
 // Add adds all resources in other into the receiver, modifies receiver
@@ -126,6 +127,7 @@ type Resources struct {
 	Memory resource.Quantity
 }
 
+// NodeSchedulingMetadata represents various parameters of a node that are considered in scheduling decisions
 type NodeSchedulingMetadata struct {
 	AvailableResources *Resources
 	CreationTimestamp  time.Time

--- a/pkg/resources/resources.go
+++ b/pkg/resources/resources.go
@@ -18,6 +18,11 @@ import (
 	"github.com/palantir/k8s-spark-scheduler-lib/pkg/apis/sparkscheduler/v1beta1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+	"time"
+)
+
+const (
+	zoneLabelPlaceholder = "default"
 )
 
 // UsageForNodes tallies resource usages per node from the given list of resource reservations
@@ -35,7 +40,7 @@ func UsageForNodes(resourceReservations []*v1beta1.ResourceReservation) NodeGrou
 	return res
 }
 
-// AvailableForNodes finds available resources by substracting current usage from allocatable per node
+// AvailableForNodes finds available resources by subtracting current usage from allocatable per node
 func AvailableForNodes(nodes []*v1.Node, currentUsage NodeGroupResources) NodeGroupResources {
 	res := NodeGroupResources(make(map[string]*Resources, len(nodes)))
 	for _, n := range nodes {
@@ -43,13 +48,38 @@ func AvailableForNodes(nodes []*v1.Node, currentUsage NodeGroupResources) NodeGr
 		if !ok {
 			currentUsageForNode = Zero()
 		}
-		res[n.Name] = substractFromResourceList(n.Status.Allocatable, currentUsageForNode)
+		res[n.Name] = subtractFromResourceList(n.Status.Allocatable, currentUsageForNode)
 	}
 	return res
 }
 
+// NodeSchedulingMetadataForNodes calculate available resources by subtracting current usage from allocatable per node
+func NodeSchedulingMetadataForNodes(nodes []*v1.Node, currentUsage NodeGroupResources) NodeGroupSchedulingMetadata {
+	nodeGroupSchedulingMetadata := make(NodeGroupSchedulingMetadata, len(nodes))
+	for _, node := range nodes {
+		currentUsageForNode, ok := currentUsage[node.Name]
+		if !ok {
+			currentUsageForNode = Zero()
+		}
+		zoneLabel, ok := node.Labels[v1.LabelZoneFailureDomain]
+		if !ok {
+			zoneLabel = zoneLabelPlaceholder
+		}
+		nodeGroupSchedulingMetadata[node.Name] = &NodeSchedulingMetadata{
+			AvailableResources: subtractFromResourceList(node.Status.Allocatable, currentUsageForNode),
+			CreationTimestamp:  node.CreationTimestamp.Time,
+			ZoneLabel: zoneLabel,
+			Unschedulable: node.Spec.Unschedulable,
+		}
+	}
+	return nodeGroupSchedulingMetadata
+}
+
 // NodeGroupResources represents resources for a group of nodes
 type NodeGroupResources map[string]*Resources
+
+// NodeGroupSchedulingMetadata represents SchedulingMetadata for a group of nodes
+type NodeGroupSchedulingMetadata map[string]*NodeSchedulingMetadata
 
 // Add adds all resources in other into the receiver, modifies receiver
 func (nodeResources NodeGroupResources) Add(other NodeGroupResources) {
@@ -61,7 +91,7 @@ func (nodeResources NodeGroupResources) Add(other NodeGroupResources) {
 	}
 }
 
-// Sub substracts all resources in other from the receiver, modifies receiver
+// Sub subtract all resources in other from the receiver, modifies receiver
 func (nodeResources NodeGroupResources) Sub(other NodeGroupResources) {
 	for node, r := range other {
 		if _, ok := nodeResources[node]; !ok {
@@ -71,7 +101,16 @@ func (nodeResources NodeGroupResources) Sub(other NodeGroupResources) {
 	}
 }
 
-func substractFromResourceList(resourceList v1.ResourceList, resources *Resources) *Resources {
+// SubtractUsage subtracts all resources in other from the receiver, modifies receiver
+func (nodesSchedulingMetadata NodeGroupSchedulingMetadata) SubtractUsage(usedResourcesByNodeName NodeGroupResources) {
+	for nodeName, usedResources := range usedResourcesByNodeName {
+		if nodeSchedulingMetadata, ok := nodesSchedulingMetadata[nodeName]; ok {
+			nodeSchedulingMetadata.AvailableResources.Sub(usedResources)
+		}
+	}
+}
+
+func subtractFromResourceList(resourceList v1.ResourceList, resources *Resources) *Resources {
 	// (a - b) == -(b - a)
 	copyResources := resources.Copy()
 	copyResources.CPU.Sub(resourceList[v1.ResourceCPU])
@@ -85,6 +124,13 @@ func substractFromResourceList(resourceList v1.ResourceList, resources *Resource
 type Resources struct {
 	CPU    resource.Quantity
 	Memory resource.Quantity
+}
+
+type NodeSchedulingMetadata struct {
+	AvailableResources *Resources
+	CreationTimestamp  time.Time
+	ZoneLabel          string
+	Unschedulable      bool
 }
 
 // Zero returns a Resources object with quantities of zero


### PR DESCRIPTION
Following up from changes made in https://github.com/palantir/k8s-spark-scheduler/pull/88, this makes the binpack aware of AZs so it can attempt to allocate an application within a single AZ. It falls back if the application doesn't fit in a single zone.

There is one possible optimization I haven’t done: We currently try to allocate the driver as well as executors in one zone. Maybe we want the binpacking to put just the executors in one zone, the driver can land up anywhere.