### PR TITLE
Replace Copy with DeepCopy on Quantity because this method is deleted in newer version

### DIFF
--- a/pkg/resources/resources.go
+++ b/pkg/resources/resources.go
@@ -161,8 +161,8 @@ func (r *Resources) AddFromReservation(reservation *v1beta1.Reservation) {
 // Copy returns a clone of the Resources object
 func (r *Resources) Copy() *Resources {
 	return &Resources{
-		CPU:    *r.CPU.Copy(),
-		Memory: *r.Memory.Copy(),
+		CPU:    r.CPU.DeepCopy(),
+		Memory: r.Memory.DeepCopy(),
 	}
 }
 


### PR DESCRIPTION
This commit has deleted Copy method on Quantity. This change makes this library compatible with newer version of apimachinery. https://github.com/kubernetes/apimachinery/commit/13d0b3fdb1a0114dab6147f28b62507f96ac87c9#diff-10d9c300e4d2054fa473090899a29f0a