### PR TITLE
Add LongLived to Demand Spec

### DIFF
--- a/pkg/apis/scaler/v1alpha1/crd_demand.go
+++ b/pkg/apis/scaler/v1alpha1/crd_demand.go
@@ -79,16 +79,16 @@ var (
 				JSONPath:    `.spec.instance-group`,
 				Description: "The instance group for the Demand request",
 			}, {
+				Name:        "long lived",
+				Type:        "boolean",
+				JSONPath:    ".spec.is-long-lived",
+				Description: "The lifecycle description of the Demand request",
+			}, {
 				Name:        "units",
 				Type:        "string",
 				JSONPath:    ".spec.units",
 				Description: "The units of the Demand request",
 				Priority:    1,
-			}, {
-				Name:        "long lived",
-				Type:        "boolean",
-				JSONPath:    ".spec.is-long-lived",
-				Description: "The lifecycle description of the Demand request",
 			}},
 			Validation: &v1beta1.CustomResourceValidation{
 				OpenAPIV3Schema: &v1beta1.JSONSchemaProps{
@@ -113,6 +113,9 @@ var (
 									Type:      "string",
 									MinLength: &oneInt,
 								},
+								"is-long-lived": {
+									Type: "boolean",
+								},
 								"units": {
 									Type: "array",
 									Items: &v1beta1.JSONSchemaPropsOrArray{
@@ -120,10 +123,9 @@ var (
 											Type:     "object",
 											Required: []string{"count", "cpu", "memory"},
 											Properties: map[string]v1beta1.JSONSchemaProps{
-												"count":         {Type: "integer", Minimum: &oneFloat},
-												"cpu":           {Type: "string", MinLength: &oneInt},
-												"memory":        {Type: "string", MinLength: &oneInt},
-												"is-long-lived": {Type: "boolean"},
+												"count":  {Type: "integer", Minimum: &oneFloat},
+												"cpu":    {Type: "string", MinLength: &oneInt},
+												"memory": {Type: "string", MinLength: &oneInt},
 											},
 										},
 									},

--- a/pkg/apis/scaler/v1alpha1/crd_demand.go
+++ b/pkg/apis/scaler/v1alpha1/crd_demand.go
@@ -54,8 +54,7 @@ var (
 			Name: DemandCustomResourceDefinitionName(),
 		},
 		Spec: v1beta1.CustomResourceDefinitionSpec{
-			Group:   SchemeGroupVersion.Group,
-			Version: SchemeGroupVersion.Version, // this is needed for k8s < 1.11
+			Group: SchemeGroupVersion.Group,
 			Versions: []v1beta1.CustomResourceDefinitionVersion{{
 				Name:    SchemeGroupVersion.Version,
 				Served:  true,
@@ -85,6 +84,11 @@ var (
 				JSONPath:    ".spec.units",
 				Description: "The units of the Demand request",
 				Priority:    1,
+			}, {
+				Name:        "long lived",
+				Type:        "boolean",
+				JSONPath:    ".spec.is-long-lived",
+				Description: "The lifecycle description of the Demand request",
 			}},
 			Validation: &v1beta1.CustomResourceValidation{
 				OpenAPIV3Schema: &v1beta1.JSONSchemaProps{
@@ -116,9 +120,10 @@ var (
 											Type:     "object",
 											Required: []string{"count", "cpu", "memory"},
 											Properties: map[string]v1beta1.JSONSchemaProps{
-												"count":  {Type: "integer", Minimum: &oneFloat},
-												"cpu":    {Type: "string", MinLength: &oneInt},
-												"memory": {Type: "string", MinLength: &oneInt},
+												"count":         {Type: "integer", Minimum: &oneFloat},
+												"cpu":           {Type: "string", MinLength: &oneInt},
+												"memory":        {Type: "string", MinLength: &oneInt},
+												"is-long-lived": {Type: "boolean"},
 											},
 										},
 									},

--- a/pkg/apis/scaler/v1alpha1/types_demand.go
+++ b/pkg/apis/scaler/v1alpha1/types_demand.go
@@ -19,17 +19,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-const (
-// BufferDemandLabel is a label that specifies whether
-// a Demand is a Buffer.
-// A Buffer is an amount of
-// compute resources that is left unused but ready
-// for quick reservation should there be need.
-// While demands go once from pending to fulfilled,
-// Buffer demands can cycle between pending and fulfilled
-// multiple times.
-)
-
 // +genclient
 // +genclient:noStatus
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/apis/scaler/v1alpha1/types_demand.go
+++ b/pkg/apis/scaler/v1alpha1/types_demand.go
@@ -20,15 +20,14 @@ import (
 )
 
 const (
-	// BufferDemandLabel is a label that specifies whether
-	// a Demand is a Buffer.
-	// A Buffer is an amount of
-	// compute resources that is left unused but ready
-	// for quick reservation should there be need.
-	// While demands go once from pending to fulfilled,
-	// Buffer demands can cycle between pending and fulfilled
-	// multiple times.
-	BufferDemandLabel = "com.palantir.compute/buffer"
+// BufferDemandLabel is a label that specifies whether
+// a Demand is a Buffer.
+// A Buffer is an amount of
+// compute resources that is left unused but ready
+// for quick reservation should there be need.
+// While demands go once from pending to fulfilled,
+// Buffer demands can cycle between pending and fulfilled
+// multiple times.
 )
 
 // +genclient
@@ -48,6 +47,16 @@ type Demand struct {
 type DemandSpec struct {
 	Units         []DemandUnit `json:"units"`
 	InstanceGroup string       `json:"instance-group"`
+
+	// IsLongLived changes the lifecycle for a demand from
+	// ephemeral and immutable to long-lived and mutable.
+	// This is useful to set a buffer in an instance-group:
+	// an amount of compute resources that is left unused
+	// but ready for quick reservation should there be need.
+	// While regular demands go once from pending to fulfilled,
+	// long-lived demands can cycle between pending and fulfilled
+	// multiple times.
+	IsLongLived bool `json:"is-long-lived"`
 }
 
 // DemandStatus represents the status a demand object is in

--- a/pkg/apis/scaler/v1alpha1/types_demand.go
+++ b/pkg/apis/scaler/v1alpha1/types_demand.go
@@ -19,6 +19,18 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+const (
+	// BufferDemandLabel is a label that specifies whether
+	// a Demand is a Buffer.
+	// A Buffer is an amount of
+	// compute resources that is left unused but ready
+	// for quick reservation should there be need.
+	// While demands go once from pending to fulfilled,
+	// Buffer demands can cycle between pending and fulfilled
+	// multiple times.
+	BufferDemandLabel = "com.palantir.compute/buffer"
+)
+
 // +genclient
 // +genclient:noStatus
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/apis/scaler/v1alpha1/types_demand.go
+++ b/pkg/apis/scaler/v1alpha1/types_demand.go
@@ -42,9 +42,6 @@ type DemandSpec struct {
 	// This is useful to set a buffer in an instance-group:
 	// an amount of compute resources that is left unused
 	// but ready for quick reservation should there be need.
-	// While regular demands go once from pending to fulfilled,
-	// long-lived demands can cycle between pending and fulfilled
-	// multiple times.
 	IsLongLived bool `json:"is-long-lived"`
 }
 


### PR DESCRIPTION
This is referred on the Buffer Demands RFC.

Long lived demands will be used to implement buffers inside the instance groups.