### PR TITLE
Add last transition time to demand status

### DIFF
--- a/pkg/apis/scaler/v1alpha1/crd_demand.go
+++ b/pkg/apis/scaler/v1alpha1/crd_demand.go
@@ -74,6 +74,12 @@ var (
 				JSONPath:    ".status.phase",
 				Description: "The phase of the Demand request",
 			}, {
+				Name:        "last transition time",
+				Type:        "string",
+				Format:      "date-time",
+				JSONPath:    ".status.last-transition-time",
+				Description: "The timestamp of the last phase transition of the Demand request",
+			},{
 				Name:        "instance group",
 				Type:        "string",
 				JSONPath:    `.spec.instance-group`,
@@ -102,6 +108,9 @@ var (
 								"phase": {
 									Type: "string",
 									Enum: getAllowedDemandPhasesEnum(),
+								},
+								"last-transition-time": {
+									Type: "string",
 								},
 							},
 						},

--- a/pkg/apis/scaler/v1alpha1/crd_demand.go
+++ b/pkg/apis/scaler/v1alpha1/crd_demand.go
@@ -79,7 +79,7 @@ var (
 				Format:      "date-time",
 				JSONPath:    ".status.last-transition-time",
 				Description: "The timestamp of the last phase transition of the Demand request",
-			},{
+			}, {
 				Name:        "instance group",
 				Type:        "string",
 				JSONPath:    `.spec.instance-group`,

--- a/pkg/apis/scaler/v1alpha1/crd_demand.go
+++ b/pkg/apis/scaler/v1alpha1/crd_demand.go
@@ -74,12 +74,6 @@ var (
 				JSONPath:    ".status.phase",
 				Description: "The phase of the Demand request",
 			}, {
-				Name:        "last transition time",
-				Type:        "string",
-				Format:      "date-time",
-				JSONPath:    ".status.last-transition-time",
-				Description: "The timestamp of the last phase transition of the Demand request",
-			}, {
 				Name:        "instance group",
 				Type:        "string",
 				JSONPath:    `.spec.instance-group`,
@@ -110,7 +104,7 @@ var (
 									Enum: getAllowedDemandPhasesEnum(),
 								},
 								"last-transition-time": {
-									Type: "string",
+									Type: "date-time",
 								},
 							},
 						},

--- a/pkg/apis/scaler/v1alpha1/types_demand.go
+++ b/pkg/apis/scaler/v1alpha1/types_demand.go
@@ -50,7 +50,7 @@ type DemandSpec struct {
 // DemandStatus represents the status a demand object is in
 type DemandStatus struct {
 	Phase              string    `json:"phase"`
-	lastTransitionTime time.Time `json:"last-transition-time,omitempty"`
+	lastTransitionTime time.Time `json:"last-transition-time"`
 }
 
 // DemandUnit represents a single unit of demand as a count of CPU and Memory requirements

--- a/pkg/apis/scaler/v1alpha1/types_demand.go
+++ b/pkg/apis/scaler/v1alpha1/types_demand.go
@@ -15,8 +15,6 @@
 package v1alpha1
 
 import (
-	"time"
-
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -49,8 +47,8 @@ type DemandSpec struct {
 
 // DemandStatus represents the status a demand object is in
 type DemandStatus struct {
-	Phase              string    `json:"phase"`
-	LastTransitionTime time.Time `json:"last-transition-time"`
+	Phase              string      `json:"phase"`
+	LastTransitionTime metav1.Time `json:"last-transition-time"`
 }
 
 // DemandUnit represents a single unit of demand as a count of CPU and Memory requirements

--- a/pkg/apis/scaler/v1alpha1/types_demand.go
+++ b/pkg/apis/scaler/v1alpha1/types_demand.go
@@ -15,6 +15,8 @@
 package v1alpha1
 
 import (
+	"time"
+
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -47,7 +49,8 @@ type DemandSpec struct {
 
 // DemandStatus represents the status a demand object is in
 type DemandStatus struct {
-	Phase string `json:"phase"`
+	Phase              string    `json:"phase"`
+	lastTransitionTime time.Time `json:"last-transition-time,omitempty"`
 }
 
 // DemandUnit represents a single unit of demand as a count of CPU and Memory requirements

--- a/pkg/apis/scaler/v1alpha1/types_demand.go
+++ b/pkg/apis/scaler/v1alpha1/types_demand.go
@@ -50,7 +50,7 @@ type DemandSpec struct {
 // DemandStatus represents the status a demand object is in
 type DemandStatus struct {
 	Phase              string    `json:"phase"`
-	lastTransitionTime time.Time `json:"last-transition-time"`
+	LastTransitionTime time.Time `json:"last-transition-time"`
 }
 
 // DemandUnit represents a single unit of demand as a count of CPU and Memory requirements


### PR DESCRIPTION
Having the timestamp of the last transition is important to produce metrics that rely on when was the demand status last updated.