### PR TITLE
Fix last transition time type

### DIFF
--- a/pkg/apis/scaler/v1alpha1/crd_demand.go
+++ b/pkg/apis/scaler/v1alpha1/crd_demand.go
@@ -104,7 +104,7 @@ var (
 									Enum: getAllowedDemandPhasesEnum(),
 								},
 								"last-transition-time": {
-									Type: "string",
+									Type:   "string",
 									Format: "date-time",
 								},
 							},

--- a/pkg/apis/scaler/v1alpha1/crd_demand.go
+++ b/pkg/apis/scaler/v1alpha1/crd_demand.go
@@ -104,7 +104,8 @@ var (
 									Enum: getAllowedDemandPhasesEnum(),
 								},
 								"last-transition-time": {
-									Type: "date-time",
+									Type: "string",
+									Format: "date-time",
 								},
 							},
 						},


### PR DESCRIPTION
For [date-time objects](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#dataTypes), type should be string while the format should be specified as date-time instead.