### PR TITLE
Adds a SetMaxResource method to Resources

### DIFF
--- a/pkg/resources/resources.go
+++ b/pkg/resources/resources.go
@@ -188,13 +188,13 @@ func (r *Resources) AddFromResourceList(resourceList v1.ResourceList) {
 
 // SetMaxResource modifies the receiver in place to set each resource to the greater value of itself or the corresponding resource in resourceList
 func (r *Resources) SetMaxResource(resourceList v1.ResourceList) {
-	cpuResource := resourceList[v1.ResourceCPU].DeepCopy()
-	memResource := resourceList[v1.ResourceMemory].DeepCopy()
+	cpuResource := resourceList[v1.ResourceCPU]
+	memResource := resourceList[v1.ResourceMemory]
 	if cpuResource.Cmp(r.CPU) > 0 {
-		r.CPU = cpuResource
+		r.CPU = cpuResource.DeepCopy()
 	}
 	if memResource.Cmp(r.Memory) > 0 {
-		r.Memory = memResource
+		r.Memory = memResource.DeepCopy()
 	}
 }
 

--- a/pkg/resources/resources.go
+++ b/pkg/resources/resources.go
@@ -188,11 +188,13 @@ func (r *Resources) AddFromResourceList(resourceList v1.ResourceList) {
 
 // SetMaxResource modifies the receiver in place to set each resource to the greater value of itself or the corresponding resource in resourceList
 func (r *Resources) SetMaxResource(resourceList v1.ResourceList) {
-	if resourceList[v1.ResourceCPU].Cmp(r.CPU) > 0 {
-		r.CPU = resourceList[v1.ResourceCPU].DeepCopy()
+	cpuResource := resourceList[v1.ResourceCPU].DeepCopy()
+	memResource := resourceList[v1.ResourceMemory].DeepCopy()
+	if cpuResource.Cmp(r.CPU) > 0 {
+		r.CPU = cpuResource
 	}
-	if resourceList[v1.ResourceMemory].Cmp(r.Memory) > 0 {
-		r.Memory = resourceList[v1.ResourceMemory].DeepCopy()
+	if memResource.Cmp(r.Memory) > 0 {
+		r.Memory = memResource
 	}
 }
 

--- a/pkg/resources/resources.go
+++ b/pkg/resources/resources.go
@@ -186,6 +186,16 @@ func (r *Resources) AddFromResourceList(resourceList v1.ResourceList) {
 	r.Memory.Add(resourceList[v1.ResourceMemory])
 }
 
+// SetMaxResource modifies the receiver in place to set each resource to the greater value of itself or the corresponding resource in resourceList
+func (r *Resources) SetMaxResource(resourceList v1.ResourceList) {
+	if resourceList[v1.ResourceCPU].Cmp(r.CPU) > 0 {
+		r.CPU = resourceList[v1.ResourceCPU].DeepCopy()
+	}
+	if resourceList[v1.ResourceMemory].Cmp(r.Memory) > 0 {
+		r.Memory = resourceList[v1.ResourceMemory].DeepCopy()
+	}
+}
+
 // GreaterThan returns true if either the CPU or Memory quantities of this object are greater than those
 // of other
 func (r *Resources) GreaterThan(other *Resources) bool {


### PR DESCRIPTION
This will be used by Spark Scheduler Extender to consider the resource request for a pod as the maximum between the requests of the init container and the sum of containers.