### PR TITLE
improvement: Make the demand last transition time an optional parameter

### DIFF
--- a/pkg/apis/scaler/v1alpha1/crd_demand.go
+++ b/pkg/apis/scaler/v1alpha1/crd_demand.go
@@ -104,8 +104,9 @@ var (
 									Enum: getAllowedDemandPhasesEnum(),
 								},
 								"last-transition-time": {
-									Type:   "string",
-									Format: "date-time",
+									Type:     "string",
+									Format:   "date-time",
+									Nullable: true,
 								},
 							},
 						},

--- a/pkg/apis/scaler/v1alpha1/types_demand.go
+++ b/pkg/apis/scaler/v1alpha1/types_demand.go
@@ -47,8 +47,12 @@ type DemandSpec struct {
 
 // DemandStatus represents the status a demand object is in
 type DemandStatus struct {
+	// Phase denotes the demand phase.
 	Phase              string       `json:"phase"`
-	LastTransitionTime *metav1.Time `json:"last-transition-time,omitempty"`
+	// LastTransitionTime denotes the last transition time of the demand phase.
+	// If left empty, defaults to the creation time of the demand.
+	// +optional
+	LastTransitionTime metav1.Time `json:"last-transition-time,omitempty"`
 }
 
 // DemandUnit represents a single unit of demand as a count of CPU and Memory requirements

--- a/pkg/apis/scaler/v1alpha1/types_demand.go
+++ b/pkg/apis/scaler/v1alpha1/types_demand.go
@@ -48,7 +48,7 @@ type DemandSpec struct {
 // DemandStatus represents the status a demand object is in
 type DemandStatus struct {
 	Phase              string      `json:"phase"`
-	LastTransitionTime metav1.Time `json:"last-transition-time"`
+	LastTransitionTime metav1.Time `json:"last-transition-time,omitempty"`
 }
 
 // DemandUnit represents a single unit of demand as a count of CPU and Memory requirements

--- a/pkg/apis/scaler/v1alpha1/types_demand.go
+++ b/pkg/apis/scaler/v1alpha1/types_demand.go
@@ -48,7 +48,7 @@ type DemandSpec struct {
 // DemandStatus represents the status a demand object is in
 type DemandStatus struct {
 	// Phase denotes the demand phase.
-	Phase              string       `json:"phase"`
+	Phase string `json:"phase"`
 	// LastTransitionTime denotes the last transition time of the demand phase.
 	// If left empty, defaults to the creation time of the demand.
 	// +optional

--- a/pkg/apis/scaler/v1alpha1/types_demand.go
+++ b/pkg/apis/scaler/v1alpha1/types_demand.go
@@ -47,8 +47,8 @@ type DemandSpec struct {
 
 // DemandStatus represents the status a demand object is in
 type DemandStatus struct {
-	Phase              string      `json:"phase"`
-	LastTransitionTime metav1.Time `json:"last-transition-time,omitempty"`
+	Phase              string       `json:"phase"`
+	LastTransitionTime *metav1.Time `json:"last-transition-time,omitempty"`
 }
 
 // DemandUnit represents a single unit of demand as a count of CPU and Memory requirements


### PR DESCRIPTION
## Summary
This is required in order to avoid serialization errors when the parameter is initially not set.

