### PR TITLE
improvement: Enable status subresource on Demand CRD

### DIFF
--- a/pkg/apis/scaler/v1alpha1/crd_demand.go
+++ b/pkg/apis/scaler/v1alpha1/crd_demand.go
@@ -61,6 +61,9 @@ var (
 				Storage: true,
 			}},
 			Scope: v1beta1.NamespaceScoped,
+			Subresources: &v1beta1.CustomResourceSubresources{
+				Status: &v1beta1.CustomResourceSubresourceStatus{},
+			},
 			Names: v1beta1.CustomResourceDefinitionNames{
 				Plural:     pluralName,
 				Singular:   "demand",

--- a/pkg/apis/scaler/v1alpha1/types_demand.go
+++ b/pkg/apis/scaler/v1alpha1/types_demand.go
@@ -20,7 +20,6 @@ import (
 )
 
 // +genclient
-// +genclient:noStatus
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // Demand represents currently unschedulable resources.

--- a/pkg/client/clientset/versioned/typed/scaler/v1alpha1/demand.go
+++ b/pkg/client/clientset/versioned/typed/scaler/v1alpha1/demand.go
@@ -24,6 +24,7 @@ type DemandsGetter interface {
 type DemandInterface interface {
 	Create(ctx context.Context, demand *v1alpha1.Demand, opts v1.CreateOptions) (*v1alpha1.Demand, error)
 	Update(ctx context.Context, demand *v1alpha1.Demand, opts v1.UpdateOptions) (*v1alpha1.Demand, error)
+	UpdateStatus(ctx context.Context, demand *v1alpha1.Demand, opts v1.UpdateOptions) (*v1alpha1.Demand, error)
 	Delete(ctx context.Context, name string, opts v1.DeleteOptions) error
 	DeleteCollection(ctx context.Context, opts v1.DeleteOptions, listOpts v1.ListOptions) error
 	Get(ctx context.Context, name string, opts v1.GetOptions) (*v1alpha1.Demand, error)
@@ -112,6 +113,22 @@ func (c *demands) Update(ctx context.Context, demand *v1alpha1.Demand, opts v1.U
 		Namespace(c.ns).
 		Resource("demands").
 		Name(demand.Name).
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Body(demand).
+		Do(ctx).
+		Into(result)
+	return
+}
+
+// UpdateStatus was generated because the type contains a Status member.
+// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
+func (c *demands) UpdateStatus(ctx context.Context, demand *v1alpha1.Demand, opts v1.UpdateOptions) (result *v1alpha1.Demand, err error) {
+	result = &v1alpha1.Demand{}
+	err = c.client.Put().
+		Namespace(c.ns).
+		Resource("demands").
+		Name(demand.Name).
+		SubResource("status").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Body(demand).
 		Do(ctx).

--- a/pkg/client/clientset/versioned/typed/scaler/v1alpha1/fake/fake_demand.go
+++ b/pkg/client/clientset/versioned/typed/scaler/v1alpha1/fake/fake_demand.go
@@ -86,6 +86,18 @@ func (c *FakeDemands) Update(ctx context.Context, demand *v1alpha1.Demand, opts 
 	return obj.(*v1alpha1.Demand), err
 }
 
+// UpdateStatus was generated because the type contains a Status member.
+// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
+func (c *FakeDemands) UpdateStatus(ctx context.Context, demand *v1alpha1.Demand, opts v1.UpdateOptions) (*v1alpha1.Demand, error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewUpdateSubresourceAction(demandsResource, "status", c.ns, demand), &v1alpha1.Demand{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*v1alpha1.Demand), err
+}
+
 // Delete takes name of the demand and deletes it. Returns an error if one occurs.
 func (c *FakeDemands) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
 	_, err := c.Fake.


### PR DESCRIPTION
This will allow changes to spec vs status to be handled distinctly with no trampling over each other.