### PR TITLE
Fix: Add Update Status function, override storage version. 

### DIFF
--- a/pkg/apis/scaler/v1alpha2/crd_demand.go
+++ b/pkg/apis/scaler/v1alpha2/crd_demand.go
@@ -146,6 +146,9 @@ var (
 func DemandCustomResourceDefinition(webhook *v1.WebhookClientConfig, supportedVersions ...v1.CustomResourceDefinitionVersion) *v1.CustomResourceDefinition {
 	demand := demandDefinition.DeepCopy()
 	demand.Spec.Conversion.Webhook.ClientConfig = webhook
+	for _, version := range supportedVersions {
+		version.Storage = false
+	}
 	demand.Spec.Versions = append(demand.Spec.Versions, supportedVersions...)
 	return demand
 }

--- a/pkg/apis/scaler/v1alpha2/crd_demand.go
+++ b/pkg/apis/scaler/v1alpha2/crd_demand.go
@@ -146,8 +146,8 @@ var (
 func DemandCustomResourceDefinition(webhook *v1.WebhookClientConfig, supportedVersions ...v1.CustomResourceDefinitionVersion) *v1.CustomResourceDefinition {
 	demand := demandDefinition.DeepCopy()
 	demand.Spec.Conversion.Webhook.ClientConfig = webhook
-	for _, version := range supportedVersions {
-		version.Storage = false
+	for i := range supportedVersions {
+		supportedVersions[i].Storage = false
 	}
 	demand.Spec.Versions = append(demand.Spec.Versions, supportedVersions...)
 	return demand

--- a/pkg/apis/scaler/v1alpha2/types_demand.go
+++ b/pkg/apis/scaler/v1alpha2/types_demand.go
@@ -63,7 +63,6 @@ var (
 )
 
 // +genclient
-// +genclient:noStatus
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // Demand represents currently unschedulable resources.

--- a/pkg/client/clientset/versioned/typed/scaler/v1alpha2/demand.go
+++ b/pkg/client/clientset/versioned/typed/scaler/v1alpha2/demand.go
@@ -24,6 +24,7 @@ type DemandsGetter interface {
 type DemandInterface interface {
 	Create(ctx context.Context, demand *v1alpha2.Demand, opts v1.CreateOptions) (*v1alpha2.Demand, error)
 	Update(ctx context.Context, demand *v1alpha2.Demand, opts v1.UpdateOptions) (*v1alpha2.Demand, error)
+	UpdateStatus(ctx context.Context, demand *v1alpha2.Demand, opts v1.UpdateOptions) (*v1alpha2.Demand, error)
 	Delete(ctx context.Context, name string, opts v1.DeleteOptions) error
 	DeleteCollection(ctx context.Context, opts v1.DeleteOptions, listOpts v1.ListOptions) error
 	Get(ctx context.Context, name string, opts v1.GetOptions) (*v1alpha2.Demand, error)
@@ -112,6 +113,22 @@ func (c *demands) Update(ctx context.Context, demand *v1alpha2.Demand, opts v1.U
 		Namespace(c.ns).
 		Resource("demands").
 		Name(demand.Name).
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Body(demand).
+		Do(ctx).
+		Into(result)
+	return
+}
+
+// UpdateStatus was generated because the type contains a Status member.
+// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
+func (c *demands) UpdateStatus(ctx context.Context, demand *v1alpha2.Demand, opts v1.UpdateOptions) (result *v1alpha2.Demand, err error) {
+	result = &v1alpha2.Demand{}
+	err = c.client.Put().
+		Namespace(c.ns).
+		Resource("demands").
+		Name(demand.Name).
+		SubResource("status").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Body(demand).
 		Do(ctx).

--- a/pkg/client/clientset/versioned/typed/scaler/v1alpha2/fake/fake_demand.go
+++ b/pkg/client/clientset/versioned/typed/scaler/v1alpha2/fake/fake_demand.go
@@ -86,6 +86,18 @@ func (c *FakeDemands) Update(ctx context.Context, demand *v1alpha2.Demand, opts 
 	return obj.(*v1alpha2.Demand), err
 }
 
+// UpdateStatus was generated because the type contains a Status member.
+// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
+func (c *FakeDemands) UpdateStatus(ctx context.Context, demand *v1alpha2.Demand, opts v1.UpdateOptions) (*v1alpha2.Demand, error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewUpdateSubresourceAction(demandsResource, "status", c.ns, demand), &v1alpha2.Demand{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*v1alpha2.Demand), err
+}
+
 // Delete takes name of the demand and deletes it. Returns an error if one occurs.
 func (c *FakeDemands) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
 	_, err := c.Fake.


### PR DESCRIPTION
Tested on my dev cluster. Conversion hook works fully. 
- Add Update status function, missed that Ashray added it. 
- Override storage version of supported versions. (there can only be one storage version)