### PR TITLE
Change storage version of resource reservation v1beta2 to be false

### DIFF
--- a/pkg/apis/sparkscheduler/v1beta2/crd_resource_reservation.go
+++ b/pkg/apis/sparkscheduler/v1beta2/crd_resource_reservation.go
@@ -23,7 +23,7 @@ import (
 var v1beta2VersionDefinition = v1.CustomResourceDefinitionVersion{
 	Name:    "v1beta2",
 	Served:  true,
-	Storage: true,
+	Storage: false,
 	AdditionalPrinterColumns: []v1.CustomResourceColumnDefinition{{
 		Name:        "driver",
 		Type:        "string",


### PR DESCRIPTION
This allows us to roll out safely, we will make clients use v1beta2 forcing use of the conversion webhook and allowing easy rollback.
Only after this has been verified will we switch the storage version.