### PR TITLE
Remove setting storage of other versions to false

### DIFF
--- a/pkg/apis/sparkscheduler/v1beta2/crd_resource_reservation.go
+++ b/pkg/apis/sparkscheduler/v1beta2/crd_resource_reservation.go
@@ -110,9 +110,6 @@ var resourceReservationDefinition = &v1.CustomResourceDefinition{
 func ResourceReservationCustomResourceDefinition(webhook *v1.WebhookClientConfig, supportedVersions ...v1.CustomResourceDefinitionVersion) *v1.CustomResourceDefinition {
 	resourceReservation := resourceReservationDefinition.DeepCopy()
 	resourceReservation.Spec.Conversion.Webhook.ClientConfig = webhook
-	for i := range supportedVersions {
-		supportedVersions[i].Storage = false
-	}
 	resourceReservation.Spec.Versions = append(resourceReservation.Spec.Versions, supportedVersions...)
 	return resourceReservation
 }


### PR DESCRIPTION
We dont want to set all other versions storage to false until we use v1beta2 as the storage version