### PR TITLE
Add resource reservations v1beta2 as a storage version

### DIFF
--- a/pkg/apis/sparkscheduler/v1beta2/crd_resource_reservation.go
+++ b/pkg/apis/sparkscheduler/v1beta2/crd_resource_reservation.go
@@ -23,7 +23,7 @@ import (
 var v1beta2VersionDefinition = v1.CustomResourceDefinitionVersion{
 	Name:    "v1beta2",
 	Served:  true,
-	Storage: false,
+	Storage: true,
 	AdditionalPrinterColumns: []v1.CustomResourceColumnDefinition{{
 		Name:        "driver",
 		Type:        "string",


### PR DESCRIPTION
As part of the resource reservations migration to v1beta2 we need to update the storage version to v1beta2. Note that we explicitly want to keep v1beta1 as a storage version as per https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definition-versioning/#upgrade-existing-objects-to-a-new-stored-version