### PR TITLE
Add SingleAzPackTightly Binpack

### DIFF
--- a/pkg/binpack/single_az_pack_tightly.go
+++ b/pkg/binpack/single_az_pack_tightly.go
@@ -1,0 +1,61 @@
+// Copyright (c) 2019 Palantir Technologies. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package binpack
+
+import (
+	"context"
+
+	"github.com/palantir/k8s-spark-scheduler-lib/pkg/resources"
+)
+
+// SingleAZTightlyPack is a SparkBinPackFunction that tries to put the driver pod
+// to as prior nodes as possible before trying to tightly pack executors
+// while also ensuring that we can fit everything in a single AZ.
+// If it cannot fit into a single AZ binpacking fails
+var SingleAZTightlyPack = SparkBinPackFunction(func(
+	ctx context.Context,
+	driverResources, executorResources *resources.Resources,
+	executorCount int,
+	driverNodePriorityOrder, executorNodePriorityOrder []string,
+	nodesSchedulingMetadata resources.NodeGroupSchedulingMetadata) (string, []string, bool) {
+
+	driverNodePriorityOrderByZone := groupNodesByZone(driverNodePriorityOrder, nodesSchedulingMetadata)
+	executorNodePriorityOrderByZone := groupNodesByZone(executorNodePriorityOrder, nodesSchedulingMetadata)
+
+	for zone, driverNodePriorityOrderForZone := range driverNodePriorityOrderByZone {
+		executorNodePriorityOrderForZone, ok := executorNodePriorityOrderByZone[zone]
+		if !ok {
+			continue
+		}
+		driverNode, executorNodes, hasCapacity := SparkBinPack(ctx, driverResources, executorResources, executorCount, driverNodePriorityOrderForZone, executorNodePriorityOrderForZone, nodesSchedulingMetadata, tightlyPackExecutors)
+		if hasCapacity {
+			return driverNode, executorNodes, hasCapacity
+		}
+	}
+	return "", nil, false
+})
+
+func groupNodesByZone(nodeNames []string, nodesSchedulingMetadata resources.NodeGroupSchedulingMetadata) map[string][]string {
+	nodeNamesByZone := make(map[string][]string)
+	for _, nodeName := range nodeNames {
+		nodesSchedulingMetadata, ok := nodesSchedulingMetadata[nodeName]
+		if !ok {
+			continue
+		}
+		zoneLabel := nodesSchedulingMetadata.ZoneLabel
+		nodeNamesByZone[zoneLabel] = append(nodeNamesByZone[zoneLabel], nodeName)
+	}
+	return nodeNamesByZone
+}

--- a/pkg/binpack/single_az_pack_tightly.go
+++ b/pkg/binpack/single_az_pack_tightly.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Palantir Technologies. All rights reserved.
+// Copyright (c) 2022 Palantir Technologies. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/binpack/single_az_pack_tightly_test.go
+++ b/pkg/binpack/single_az_pack_tightly_test.go
@@ -1,0 +1,122 @@
+// Copyright (c) 2019 Palantir Technologies. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package binpack
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/palantir/k8s-spark-scheduler-lib/pkg/resources"
+)
+
+func TestSingleAZTightlyPack(t *testing.T) {
+	tests := []struct {
+		name                    string
+		driverResources         *resources.Resources
+		executorResources       *resources.Resources
+		numExecutors            int
+		nodesSchedulingMetadata resources.NodeGroupSchedulingMetadata
+		nodePriorityOrder       []string
+		expectedDriverNode      string
+		willFit                 bool
+		expectedCounts          map[string]int
+	}{{
+		name:              "picks the first zone when application fits entirely in either of the zones",
+		driverResources:   createResources(1, 3, 1),
+		executorResources: createResources(2, 5, 2),
+		numExecutors:      2,
+		nodesSchedulingMetadata: resources.NodeGroupSchedulingMetadata(map[string]*resources.NodeSchedulingMetadata{
+			"n1_z1": createSchedulingMetadata(4, 5, 4, "z1"),
+			"n1_z2": createSchedulingMetadata(4, 8, 4, "z2"),
+			"n2_z1": createSchedulingMetadata(6, 15, 6, "z1"),
+			"n2_z2": createSchedulingMetadata(6, 20, 6, "z2"),
+		}),
+		nodePriorityOrder:  []string{"n1_z1", "n1_z2", "n2_z1", "n2_z2"},
+		expectedDriverNode: "n1_z1",
+		willFit:            true,
+		expectedCounts:     map[string]int{"n2_z1": 2},
+	}, {
+		name:              "picks the zone where application fits entirely",
+		driverResources:   createResources(1, 3, 1),
+		executorResources: createResources(2, 5, 1),
+		numExecutors:      2,
+		nodesSchedulingMetadata: resources.NodeGroupSchedulingMetadata(map[string]*resources.NodeSchedulingMetadata{
+			"n1_z1": createSchedulingMetadata(4, 5, 1, "z1"),
+			"n1_z2": createSchedulingMetadata(4, 8, 2, "z2"),
+			"n2_z2": createSchedulingMetadata(6, 20, 10, "z2"),
+		}),
+		nodePriorityOrder:  []string{"n1_z1", "n1_z2", "n2_z2"},
+		expectedDriverNode: "n1_z2",
+		willFit:            true,
+		expectedCounts:     map[string]int{"n1_z2": 1, "n2_z2": 1},
+	}, {
+		name:              "Does not schedule if application does not fit entirely in one zone",
+		driverResources:   createResources(1, 1, 1),
+		executorResources: createResources(2, 1, 1),
+		numExecutors:      2,
+		nodesSchedulingMetadata: resources.NodeGroupSchedulingMetadata(map[string]*resources.NodeSchedulingMetadata{
+			"n1_z1": createSchedulingMetadata(4, 5, 1, "z1"),
+			"n2_z1": createSchedulingMetadata(4, 6, 1, "z1"),
+			"n1_z2": createSchedulingMetadata(4, 7, 1, "z2"),
+			"n2_z2": createSchedulingMetadata(6, 7, 0, "z2"),
+		}),
+		nodePriorityOrder:  []string{"n1_z1", "n2_z1", "n1_z2", "n2_z2"},
+		expectedDriverNode: "n1_z1",
+		willFit:            false,
+	}, {
+		name:              "executor gpu does not fit",
+		driverResources:   createResources(1, 1, 1),
+		executorResources: createResources(1, 1, 1),
+		numExecutors:      4,
+		nodesSchedulingMetadata: resources.NodeGroupSchedulingMetadata(map[string]*resources.NodeSchedulingMetadata{
+			"n1_z1": createSchedulingMetadata(4, 4, 4, "z1"),
+			"n1_z2": createSchedulingMetadata(128, 128, 0, "z2"),
+		}),
+		nodePriorityOrder:  []string{"n1_z1", "n1_z2"},
+		expectedDriverNode: "n1_z1",
+		willFit:            false,
+	},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			driver, executors, ok := SingleAZTightlyPack(
+				context.Background(),
+				test.driverResources,
+				test.executorResources,
+				test.numExecutors,
+				test.nodePriorityOrder,
+				test.nodePriorityOrder,
+				test.nodesSchedulingMetadata)
+			if ok != test.willFit {
+				t.Fatalf("mismatch in willFit, expected: %v, got: %v", test.willFit, ok)
+			}
+			if !test.willFit {
+				return
+			}
+			if driver != test.expectedDriverNode {
+				t.Fatalf("mismatch in driver node, expected: %v, got: %v", test.expectedDriverNode, driver)
+			}
+			resultCounts := map[string]int{}
+			for _, node := range executors {
+				resultCounts[node]++
+			}
+			if test.expectedCounts != nil && !reflect.DeepEqual(resultCounts, test.expectedCounts) {
+				t.Fatalf("executor nodes are not equal, expected: %v, got: %v", test.expectedCounts, resultCounts)
+			}
+		})
+	}
+}

--- a/pkg/binpack/single_az_pack_tightly_test.go
+++ b/pkg/binpack/single_az_pack_tightly_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Palantir Technologies. All rights reserved.
+// Copyright (c) 2022 Palantir Technologies. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.


### PR DESCRIPTION
* Cross AZ networking is often very expensive.
* Currently all binpack algorithms will schedule across AZ boundaries if we can fit the application into the cluster.
* In order to reduce networking costs, this algorithm will only schedule applications inside of a single AZ.

It behaves identically to the `AzAwareTightlyPack` algo apart from it will not schedule an application across AZ boundaries
