### PR TITLE
Use v1beta1 as storage version

### DIFF
--- a/pkg/apis/sparkscheduler/v1beta2/crd_resource_reservation.go
+++ b/pkg/apis/sparkscheduler/v1beta2/crd_resource_reservation.go
@@ -23,7 +23,7 @@ import (
 var v1beta2VersionDefinition = v1.CustomResourceDefinitionVersion{
 	Name:    "v1beta2",
 	Served:  true,
-	Storage: true,
+	Storage: false,
 	AdditionalPrinterColumns: []v1.CustomResourceColumnDefinition{{
 		Name:        "driver",
 		Type:        "string",


### PR DESCRIPTION
Both v1beta1 and v1beta2 are set to be storage versions as of right now.
There can only be one storage version in k8s.

Eventually we should migrate to using v1beta2 as the storage version but to get back into a valid state, we should leave it as v1beta1 for now.