### PR TITLE
Add binpacking strategy to pack into the fewest bins possible

### DIFF
--- a/pkg/binpack/pack_fewest_bins.go
+++ b/pkg/binpack/pack_fewest_bins.go
@@ -1,0 +1,104 @@
+// Copyright (c) 2019 Palantir Technologies. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Copyright (c) 2023 Palantir Technologies. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package binpack
+
+import (
+	"context"
+	"sort"
+
+	"github.com/palantir/k8s-spark-scheduler-lib/pkg/resources"
+)
+
+// PackFewestBins is a SparkBinPackFunction that tries to put the driver pod
+// to as prior nodes as possible before trying to pack executors into the fewest number of bins possible
+var PackFewestBins = SparkBinPackFunction(func(
+	ctx context.Context,
+	driverResources, executorResources *resources.Resources,
+	executorCount int,
+	driverNodePriorityOrder, executorNodePriorityOrder []string,
+	nodesSchedulingMetadata resources.NodeGroupSchedulingMetadata) (string, []string, bool) {
+	return SparkBinPack(ctx, driverResources, executorResources, executorCount, driverNodePriorityOrder, executorNodePriorityOrder, nodesSchedulingMetadata, packExecutorsFewestBins)
+})
+
+type orderableNode struct {
+	name               string
+	canFitAllExecutors bool
+	availableResources *resources.Resources
+}
+
+// packExecutorsFewestBins tries to pack executors into the fewest number of bins possible. Note that it takes node
+// priority into account, but would pick nodes that fit more executors over the ones with higher priority. If there is
+// a single note that can fit all executors, node with the fewest available resources will take priority.
+func packExecutorsFewestBins(
+	ctx context.Context,
+	executorResources *resources.Resources,
+	executorCount int,
+	nodePriorityOrder []string,
+	nodesSchedulingMetadata resources.NodeGroupSchedulingMetadata,
+	reservedResources resources.NodeGroupResources) ([]string, bool) {
+	totalExecutorResources := resources.Zero()
+	for i := 0; i < executorCount; i++ {
+		totalExecutorResources.Add(executorResources)
+	}
+
+	nodesToOrder := make([]orderableNode, 0, executorCount)
+	for _, nodeName := range nodePriorityOrder {
+		nodeResources := nodesSchedulingMetadata[nodeName].AvailableResources
+		nodesToOrder = append(nodesToOrder, orderableNode{
+			name:               nodeName,
+			canFitAllExecutors: nodeResources.GreaterThan(totalExecutorResources) || nodeResources.Eq(totalExecutorResources),
+			availableResources: nodeResources,
+		})
+	}
+
+	sort.SliceStable(nodesToOrder, func(i, j int) bool {
+		return nodesToOrder[i].availableResources.GreaterThan(nodesToOrder[j].availableResources)
+	})
+
+	smallestThatFitsAllExecutors := -1
+	// TODO binary search
+	for j, node := range nodesToOrder {
+		if node.canFitAllExecutors {
+			smallestThatFitsAllExecutors = j
+		} else {
+			break
+		}
+	}
+
+	if smallestThatFitsAllExecutors != -1 {
+		nodesToOrder = nodesToOrder[smallestThatFitsAllExecutors:]
+	}
+
+	orderedNodes := make([]string, 0, len(nodesToOrder))
+	for _, node := range nodesToOrder {
+		orderedNodes = append(orderedNodes, node.name)
+	}
+
+	return tightlyPackExecutors(ctx, executorResources, executorCount, orderedNodes, nodesSchedulingMetadata, reservedResources)
+}

--- a/pkg/binpack/pack_fewest_bins_test.go
+++ b/pkg/binpack/pack_fewest_bins_test.go
@@ -1,0 +1,165 @@
+// Copyright (c) 2019 Palantir Technologies. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Copyright (c) 2022 Palantir Technologies. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package binpack
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/palantir/k8s-spark-scheduler-lib/pkg/resources"
+)
+
+func TestPackFewestBins(t *testing.T) {
+	tests := []struct {
+		name                      string
+		driverResources           *resources.Resources
+		executorResources         *resources.Resources
+		numExecutors              int
+		nodesSchedulingMetadata   resources.NodeGroupSchedulingMetadata
+		driverNodePriorityOrder   []string
+		executorNodePriorityOrder []string
+		expectedDriverNode        string
+		willFit                   bool
+		expectedCounts            map[string]int
+	}{{
+		name:              "application fits",
+		driverResources:   createResources(1, 3, 1),
+		executorResources: createResources(2, 5, 1),
+		numExecutors:      2,
+		nodesSchedulingMetadata: resources.NodeGroupSchedulingMetadata(map[string]*resources.NodeSchedulingMetadata{
+			"n1": createSchedulingMetadata(5, 10, 2, "zone1"),
+			"n2": createSchedulingMetadata(4, 5, 1, "zone1"),
+		}),
+		driverNodePriorityOrder:   []string{"n1", "n2"},
+		executorNodePriorityOrder: []string{"n2", "n1"},
+		expectedDriverNode:        "n1",
+		willFit:                   true,
+		expectedCounts:            map[string]int{"n1": 1, "n2": 1},
+	}, {
+		name:              "packs into smallest single bin",
+		driverResources:   createResources(1, 3, 1),
+		executorResources: createResources(2, 5, 1),
+		numExecutors:      5,
+		nodesSchedulingMetadata: resources.NodeGroupSchedulingMetadata(map[string]*resources.NodeSchedulingMetadata{
+			"n1": createSchedulingMetadata(11, 28, 6, "zone1"),
+			"n2": createSchedulingMetadata(100, 200, 6, "zone1"),
+		}),
+		driverNodePriorityOrder:   []string{"n1", "n2"},
+		executorNodePriorityOrder: []string{"n2", "n1"},
+		expectedDriverNode:        "n1",
+		willFit:                   true,
+		expectedCounts:            map[string]int{"n1": 5},
+	}, {
+		name:              "packs into the largest multiple bins, respecting priority",
+		driverResources:   createResources(1, 3, 1),
+		executorResources: createResources(2, 5, 1),
+		numExecutors:      5,
+		nodesSchedulingMetadata: resources.NodeGroupSchedulingMetadata(map[string]*resources.NodeSchedulingMetadata{
+			"n1": createSchedulingMetadata(7, 18, 4, "zone1"),
+			"n2": createSchedulingMetadata(4, 10, 2, "zone1"),
+			"n3": createSchedulingMetadata(4, 10, 2, "zone1"),
+		}),
+		driverNodePriorityOrder:   []string{"n1", "n2", "n3"},
+		executorNodePriorityOrder: []string{"n3", "n2", "n1"},
+		expectedDriverNode:        "n1",
+		willFit:                   true,
+		expectedCounts:            map[string]int{"n1": 3, "n3": 2},
+	}, {
+		name:              "driver memory does not fit",
+		driverResources:   createResources(2, 4, 1),
+		executorResources: createResources(1, 1, 0),
+		numExecutors:      1,
+		nodesSchedulingMetadata: resources.NodeGroupSchedulingMetadata(map[string]*resources.NodeSchedulingMetadata{
+			"n1": createSchedulingMetadata(2, 3, 1, "zone1"),
+		}),
+		driverNodePriorityOrder:   []string{"n1"},
+		executorNodePriorityOrder: []string{"n1"},
+		willFit:                   false,
+		expectedCounts:            nil,
+	}, {
+		name:              "application perfectly fits",
+		driverResources:   createResources(1, 2, 1),
+		executorResources: createResources(1, 1, 1),
+		numExecutors:      40,
+		nodesSchedulingMetadata: resources.NodeGroupSchedulingMetadata(map[string]*resources.NodeSchedulingMetadata{
+			"n1": createSchedulingMetadata(13, 14, 13, "zone1"),
+			"n2": createSchedulingMetadata(12, 12, 12, "zone1"),
+			"n3": createSchedulingMetadata(16, 16, 16, "zone1"),
+		}),
+		driverNodePriorityOrder:   []string{"n1", "n2", "n3"},
+		executorNodePriorityOrder: []string{"n3", "n2", "n1"},
+		expectedDriverNode:        "n1",
+		willFit:                   true,
+		expectedCounts:            map[string]int{"n1": 12, "n2": 12, "n3": 16},
+	}, {
+		name:              "executor gpu does not fit",
+		driverResources:   createResources(1, 1, 1),
+		executorResources: createResources(1, 1, 1),
+		numExecutors:      4,
+		nodesSchedulingMetadata: resources.NodeGroupSchedulingMetadata(map[string]*resources.NodeSchedulingMetadata{
+			"n1_z1": createSchedulingMetadata(4, 4, 4, "z1"),
+			"n1_z2": createSchedulingMetadata(128, 128, 0, "z2"),
+		}),
+		driverNodePriorityOrder:   []string{"n1", "n2"},
+		executorNodePriorityOrder: []string{"n2", "n1"},
+		expectedDriverNode:        "n1",
+		willFit:                   false,
+	},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			driver, executors, ok := PackFewestBins(
+				context.Background(),
+				test.driverResources,
+				test.executorResources,
+				test.numExecutors,
+				test.driverNodePriorityOrder,
+				test.executorNodePriorityOrder,
+				test.nodesSchedulingMetadata)
+			if ok != test.willFit {
+				t.Fatalf("mismatch in willFit, expected: %v, got: %v", test.willFit, ok)
+			}
+			if !test.willFit {
+				return
+			}
+			if driver != test.expectedDriverNode {
+				t.Fatalf("mismatch in driver node, expected: %v, got: %v", test.expectedDriverNode, driver)
+			}
+			resultCounts := map[string]int{}
+			for _, node := range executors {
+				resultCounts[node]++
+			}
+			if test.expectedCounts != nil && !reflect.DeepEqual(resultCounts, test.expectedCounts) {
+				t.Fatalf("executor nodes are not equal, expected: %v, got: %v", test.expectedCounts, resultCounts)
+			}
+		})
+	}
+}

--- a/pkg/binpack/single_az_pack_fewest_bins.go
+++ b/pkg/binpack/single_az_pack_fewest_bins.go
@@ -1,0 +1,59 @@
+// Copyright (c) 2019 Palantir Technologies. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Copyright (c) 2023 Palantir Technologies. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package binpack
+
+import (
+	"context"
+
+	"github.com/palantir/k8s-spark-scheduler-lib/pkg/resources"
+)
+
+// SingleAzPackFewestBins is a SparkBinPackFunction that uses PackFewestBins while also trying to ensure that we can fit
+// everything in a single AZ. If it cannot fit into a single AZ binpacking fails
+var SingleAzPackFewestBins = SparkBinPackFunction(func(
+	ctx context.Context,
+	driverResources, executorResources *resources.Resources,
+	executorCount int,
+	driverNodePriorityOrder, executorNodePriorityOrder []string,
+	nodesSchedulingMetadata resources.NodeGroupSchedulingMetadata) (string, []string, bool) {
+	driverNodePriorityOrderByZone := groupNodesByZone(driverNodePriorityOrder, nodesSchedulingMetadata)
+	executorNodePriorityOrderByZone := groupNodesByZone(executorNodePriorityOrder, nodesSchedulingMetadata)
+
+	for zone, driverNodePriorityOrderForZone := range driverNodePriorityOrderByZone {
+		executorNodePriorityOrderForZone, ok := executorNodePriorityOrderByZone[zone]
+		if !ok {
+			continue
+		}
+		driverNode, executorNodes, hasCapacity := PackFewestBins(ctx, driverResources, executorResources, executorCount, driverNodePriorityOrderForZone, executorNodePriorityOrderForZone, nodesSchedulingMetadata)
+		if hasCapacity {
+			return driverNode, executorNodes, hasCapacity
+		}
+	}
+	return "", nil, false
+})

--- a/pkg/binpack/single_az_pack_fewest_bins_test.go
+++ b/pkg/binpack/single_az_pack_fewest_bins_test.go
@@ -1,0 +1,136 @@
+// Copyright (c) 2019 Palantir Technologies. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Copyright (c) 2023 Palantir Technologies. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package binpack
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/palantir/k8s-spark-scheduler-lib/pkg/resources"
+)
+
+func TestSingleAZPackFewestBins(t *testing.T) {
+	tests := []struct {
+		name                    string
+		driverResources         *resources.Resources
+		executorResources       *resources.Resources
+		numExecutors            int
+		nodesSchedulingMetadata resources.NodeGroupSchedulingMetadata
+		nodePriorityOrder       []string
+		expectedDriverNode      string
+		willFit                 bool
+		expectedCounts          map[string]int
+	}{{
+		name:              "picks the first zone when application fits entirely in either of the zones",
+		driverResources:   createResources(1, 3, 1),
+		executorResources: createResources(2, 5, 2),
+		numExecutors:      2,
+		nodesSchedulingMetadata: resources.NodeGroupSchedulingMetadata(map[string]*resources.NodeSchedulingMetadata{
+			"n1_z1": createSchedulingMetadata(4, 5, 4, "z1"),
+			"n1_z2": createSchedulingMetadata(4, 8, 4, "z2"),
+			"n2_z1": createSchedulingMetadata(6, 15, 6, "z1"),
+			"n2_z2": createSchedulingMetadata(6, 20, 6, "z2"),
+		}),
+		nodePriorityOrder:  []string{"n1_z1", "n1_z2", "n2_z1", "n2_z2"},
+		expectedDriverNode: "n1_z1",
+		willFit:            true,
+		expectedCounts:     map[string]int{"n2_z1": 2},
+	}, {
+		name:              "picks the zone AND node where application fits entirely",
+		driverResources:   createResources(1, 3, 1),
+		executorResources: createResources(2, 5, 1),
+		numExecutors:      2,
+		nodesSchedulingMetadata: resources.NodeGroupSchedulingMetadata(map[string]*resources.NodeSchedulingMetadata{
+			"n1_z1": createSchedulingMetadata(4, 5, 1, "z1"),
+			"n1_z2": createSchedulingMetadata(4, 8, 2, "z2"),
+			"n2_z2": createSchedulingMetadata(6, 20, 10, "z2"),
+		}),
+		nodePriorityOrder:  []string{"n1_z1", "n1_z2", "n2_z2"},
+		expectedDriverNode: "n1_z2",
+		willFit:            true,
+		expectedCounts:     map[string]int{"n2_z2": 2},
+	}, {
+		name:              "Does not schedule if application does not fit entirely in one zone",
+		driverResources:   createResources(1, 1, 1),
+		executorResources: createResources(2, 1, 1),
+		numExecutors:      2,
+		nodesSchedulingMetadata: resources.NodeGroupSchedulingMetadata(map[string]*resources.NodeSchedulingMetadata{
+			"n1_z1": createSchedulingMetadata(4, 5, 1, "z1"),
+			"n2_z1": createSchedulingMetadata(4, 6, 1, "z1"),
+			"n1_z2": createSchedulingMetadata(4, 7, 1, "z2"),
+			"n2_z2": createSchedulingMetadata(6, 7, 0, "z2"),
+		}),
+		nodePriorityOrder:  []string{"n1_z1", "n2_z1", "n1_z2", "n2_z2"},
+		expectedDriverNode: "n1_z1",
+		willFit:            false,
+	}, {
+		name:              "executor gpu does not fit",
+		driverResources:   createResources(1, 1, 1),
+		executorResources: createResources(1, 1, 1),
+		numExecutors:      4,
+		nodesSchedulingMetadata: resources.NodeGroupSchedulingMetadata(map[string]*resources.NodeSchedulingMetadata{
+			"n1_z1": createSchedulingMetadata(4, 4, 4, "z1"),
+			"n1_z2": createSchedulingMetadata(128, 128, 0, "z2"),
+		}),
+		nodePriorityOrder:  []string{"n1_z1", "n1_z2"},
+		expectedDriverNode: "n1_z1",
+		willFit:            false,
+	},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			driver, executors, ok := SingleAzPackFewestBins(
+				context.Background(),
+				test.driverResources,
+				test.executorResources,
+				test.numExecutors,
+				test.nodePriorityOrder,
+				test.nodePriorityOrder,
+				test.nodesSchedulingMetadata)
+			if ok != test.willFit {
+				t.Fatalf("mismatch in willFit, expected: %v, got: %v", test.willFit, ok)
+			}
+			if !test.willFit {
+				return
+			}
+			if driver != test.expectedDriverNode {
+				t.Fatalf("mismatch in driver node, expected: %v, got: %v", test.expectedDriverNode, driver)
+			}
+			resultCounts := map[string]int{}
+			for _, node := range executors {
+				resultCounts[node]++
+			}
+			if test.expectedCounts != nil && !reflect.DeepEqual(resultCounts, test.expectedCounts) {
+				t.Fatalf("executor nodes are not equal, expected: %v, got: %v", test.expectedCounts, resultCounts)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Add new binpacking algorithm that tries to collocate executors as much as possible. The theory is that collocating is much more important for Spark, as long-lived applications force all hosts that have its executors to stay alive.