### PR TITLE
Add new SingleAZMinimalFragmentation strategy

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/stretchr/testify v1.8.0
 	// Pin for CVE-2022-27664
 	golang.org/x/net v0.0.0-20220906165146-f3363e06e74c // indirect
+	gopkg.in/inf.v0 v0.9.1
 	k8s.io/api v0.24.7
 	k8s.io/apiextensions-apiserver v0.24.7
 	k8s.io/apimachinery v0.24.7
@@ -50,7 +51,6 @@ require (
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/protobuf v1.27.1 // indirect
-	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/gengo v0.0.0-20211129171323-c02415ce4185 // indirect

--- a/pkg/binpack/minimal_fragmentation.go
+++ b/pkg/binpack/minimal_fragmentation.go
@@ -1,0 +1,173 @@
+// Copyright (c) 2019 Palantir Technologies. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package binpack
+
+import (
+	"context"
+	"math"
+	"sort"
+
+	"github.com/palantir/k8s-spark-scheduler-lib/pkg/resources"
+	"gopkg.in/inf.v0"
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+// MinimalFragmentation is a SparkBinPackFunction that tries to put the driver pod on the first possible node with
+// enough capacity, and then tries to pack executors onto as few nodes as possible.
+var MinimalFragmentation = SparkBinPackFunction(func(
+	ctx context.Context,
+	driverResources, executorResources *resources.Resources,
+	executorCount int,
+	driverNodePriorityOrder, executorNodePriorityOrder []string,
+	nodesSchedulingMetadata resources.NodeGroupSchedulingMetadata) (string, []string, bool) {
+	return SparkBinPack(ctx, driverResources, executorResources, executorCount, driverNodePriorityOrder, executorNodePriorityOrder, nodesSchedulingMetadata, minimalFragmentation)
+})
+
+// minimalFragmentation attempts to pack executors onto as few nodes as possible, ideally a single one
+// nodePriorityOrder is still used as a guideline, i.e. if an application can fit on multiple nodes, it will pick
+// the first eligible node according to nodePriorityOrder
+func minimalFragmentation(
+	_ context.Context,
+	executorResources *resources.Resources,
+	executorCount int,
+	nodePriorityOrder []string,
+	nodeGroupSchedulingMetadata resources.NodeGroupSchedulingMetadata,
+	reservedResources resources.NodeGroupResources) ([]string, bool) {
+	executorNodes := make([]string, 0, executorCount)
+	if executorCount == 0 {
+		return executorNodes, true
+	}
+
+	nodeCapacities := getNodeCapacities(nodePriorityOrder, nodeGroupSchedulingMetadata, reservedResources, executorResources)
+	sort.SliceStable(nodeCapacities, func(i, j int) bool {
+		return nodeCapacities[i].capacity < nodeCapacities[j].capacity
+	})
+
+	// as long as we have nodes where we could schedule executors
+	for len(nodeCapacities) > 0 {
+		// pick the first node that could fit all the executors (if there's one)
+		position := sort.Search(len(nodeCapacities), func(i int) bool {
+			return nodeCapacities[i].capacity >= executorCount
+		})
+
+		if position != len(nodeCapacities) {
+			// we found a node that has the required capacity, schedule everything there and we're done
+			return append(executorNodes, repeat(nodeCapacities[position].nodeName, executorCount)...), true
+		}
+
+		// we will need multiple nodes for scheduling, thus we'll try to schedule executors on nodes with the most capacity
+		maxCapacity := nodeCapacities[len(nodeCapacities)-1].capacity
+		position = sort.Search(len(nodeCapacities), func(i int) bool {
+			return nodeCapacities[i].capacity >= maxCapacity
+		})
+
+		// we can skip the check on position since we know at least one node will be found
+		executorNodes = append(executorNodes, repeat(nodeCapacities[position].nodeName, maxCapacity)...)
+		executorCount -= maxCapacity
+
+		// at least on paper, this is somewhat inefficient (but more readable than the alternative)
+		// to be optimized later if needed
+		nodeCapacities = append(nodeCapacities[:position], nodeCapacities[position+1:]...)
+	}
+
+	return nil, false
+}
+
+type nodeAndExecutorCapacity struct {
+	nodeName string
+	capacity int
+}
+
+func getCapacitySingleDimension(available, reserved, required resource.Quantity) int {
+	if required.IsZero() {
+		return math.MaxInt
+	}
+
+	return int(new(inf.Dec).QuoRound(
+		new(inf.Dec).Sub(available.AsDec(), reserved.AsDec()),
+		required.AsDec(),
+		0,
+		inf.RoundFloor,
+	).UnscaledBig().Int64())
+}
+
+func getNodeCapacity(available, reserved, singleExecutor *resources.Resources) int {
+	capacityConsideringCPUOnly := getCapacitySingleDimension(
+		available.CPU,
+		reserved.CPU,
+		singleExecutor.CPU,
+	)
+	capacityConsideringMemoryOnly := getCapacitySingleDimension(
+		available.Memory,
+		reserved.Memory,
+		singleExecutor.Memory,
+	)
+	capacityConsideringNvidiaGPUOnly := getCapacitySingleDimension(
+		available.NvidiaGPU,
+		reserved.NvidiaGPU,
+		singleExecutor.NvidiaGPU,
+	)
+
+	return min(capacityConsideringCPUOnly, capacityConsideringMemoryOnly, capacityConsideringNvidiaGPUOnly)
+}
+
+// getNodeCapacities' return value is ordered according to nodePriorityOrder
+// note: this will only return nodes with non-zero capacity
+func getNodeCapacities(
+	nodePriorityOrder []string,
+	nodeGroupSchedulingMetadata resources.NodeGroupSchedulingMetadata,
+	reservedResources resources.NodeGroupResources,
+	singleExecutor *resources.Resources,
+) []nodeAndExecutorCapacity {
+	capacities := make([]nodeAndExecutorCapacity, 0, len(nodePriorityOrder))
+
+	for _, nodeName := range nodePriorityOrder {
+		if nodeSchedulingMetadata, ok := nodeGroupSchedulingMetadata[nodeName]; ok {
+			reserved := resources.Zero()
+
+			if alreadyReserved, ok := reservedResources[nodeName]; ok {
+				reserved = alreadyReserved
+			}
+
+			capacity := getNodeCapacity(nodeSchedulingMetadata.AvailableResources, reserved, singleExecutor)
+
+			if capacity > 0 {
+				capacities = append(capacities, nodeAndExecutorCapacity{
+					nodeName: nodeName,
+					capacity: capacity,
+				})
+			}
+		}
+	}
+
+	return capacities
+}
+
+func min(a, b, c int) int {
+	if a <= b && a <= c {
+		return a
+	} else if b <= c {
+		return b
+	}
+	return c
+}
+
+func repeat(str string, n int) []string {
+	arr := make([]string, 0, n)
+	for i := 0; i < n; i++ {
+		arr = append(arr, str)
+	}
+	return arr
+}

--- a/pkg/binpack/minimal_fragmentation_test.go
+++ b/pkg/binpack/minimal_fragmentation_test.go
@@ -1,0 +1,315 @@
+// Copyright (c) 2019 Palantir Technologies. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package binpack
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/palantir/k8s-spark-scheduler-lib/pkg/resources"
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+func TestMin(t *testing.T) {
+	assert.Equal(t, 1, min(1, 2, 3))
+	assert.Equal(t, 1, min(2, 1, 3))
+	assert.Equal(t, 1, min(2, 3, 1))
+}
+
+func TestGetNodeCapacity(t *testing.T) {
+	singleExecutor := &resources.Resources{
+		CPU:       *resource.NewQuantity(1, resource.DecimalSI),
+		Memory:    *resource.NewQuantity(1, resource.DecimalSI),
+		NvidiaGPU: *resource.NewQuantity(1, resource.DecimalSI),
+	}
+
+	tests := []struct {
+		name           string
+		available      *resources.Resources
+		reserved       *resources.Resources
+		singleExecutor *resources.Resources
+		expected       int
+	}{{
+		name:           "no available resources",
+		available:      &resources.Resources{},
+		reserved:       resources.Zero(),
+		singleExecutor: singleExecutor,
+		expected:       0,
+	}, {
+		name:           "available resources fit exactly",
+		available:      singleExecutor,
+		reserved:       resources.Zero(),
+		singleExecutor: singleExecutor,
+		expected:       1,
+	}, {
+		name: "capacity is limited by cpu",
+		available: &resources.Resources{
+			CPU:       *resource.NewQuantity(3, resource.DecimalSI),
+			Memory:    *resource.NewQuantity(4, resource.DecimalSI),
+			NvidiaGPU: *resource.NewQuantity(4, resource.DecimalSI),
+		},
+		reserved:       resources.Zero(),
+		singleExecutor: singleExecutor,
+		expected:       3,
+	}, {
+		name: "capacity is limited by memory",
+		available: &resources.Resources{
+			CPU:       *resource.NewQuantity(4, resource.DecimalSI),
+			Memory:    *resource.NewQuantity(3, resource.DecimalSI),
+			NvidiaGPU: *resource.NewQuantity(4, resource.DecimalSI),
+		},
+		reserved:       resources.Zero(),
+		singleExecutor: singleExecutor,
+		expected:       3,
+	}, {
+		name: "capacity is limited by gpu",
+		available: &resources.Resources{
+			CPU:       *resource.NewQuantity(4, resource.DecimalSI),
+			Memory:    *resource.NewQuantity(4, resource.DecimalSI),
+			NvidiaGPU: *resource.NewQuantity(3, resource.DecimalSI),
+		},
+		reserved:       resources.Zero(),
+		singleExecutor: singleExecutor,
+		expected:       3,
+	}, {
+		name:      "does not fit due to existing reserved resources",
+		available: singleExecutor,
+		reserved: &resources.Resources{
+			CPU: *resource.NewQuantity(1, resource.DecimalSI),
+		},
+		singleExecutor: singleExecutor,
+		expected:       0,
+	},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.expected, getNodeCapacity(test.available, test.reserved, test.singleExecutor))
+		})
+	}
+}
+
+func TestMinimalFragmentation(t *testing.T) {
+	tests := []struct {
+		name                    string
+		driverResources         *resources.Resources
+		executorResources       *resources.Resources
+		numExecutors            int
+		nodesSchedulingMetadata resources.NodeGroupSchedulingMetadata
+		nodePriorityOrder       []string
+		expectedDriverNode      string
+		willFit                 bool
+		expectedCounts          map[string]int
+	}{{
+		name:              "application fits",
+		driverResources:   createResources(1, 3, 1),
+		executorResources: createResources(2, 5, 1),
+		numExecutors:      2,
+		nodesSchedulingMetadata: resources.NodeGroupSchedulingMetadata(map[string]*resources.NodeSchedulingMetadata{
+			"n1": createSchedulingMetadata(5, 10, 2, "zone1"),
+			"n2": createSchedulingMetadata(4, 5, 1, "zone1"),
+		}),
+		nodePriorityOrder:  []string{"n1", "n2"},
+		expectedDriverNode: "n1",
+		willFit:            true,
+		expectedCounts:     map[string]int{"n1": 1, "n2": 1},
+	}, {
+		name:              "when not fitting on a single node, executors are first fitted on nodes with the most available resources",
+		driverResources:   createResources(1, 3, 0),
+		executorResources: createResources(2, 5, 0),
+		numExecutors:      5,
+		nodesSchedulingMetadata: resources.NodeGroupSchedulingMetadata(map[string]*resources.NodeSchedulingMetadata{
+			"n1": createSchedulingMetadata(5, 25, 6, "zone1"),
+			"n2": createSchedulingMetadata(9, 24, 6, "zone1"),
+		}),
+		nodePriorityOrder:  []string{"n1", "n2"},
+		expectedDriverNode: "n1",
+		willFit:            true,
+		expectedCounts:     map[string]int{"n1": 1, "n2": 4},
+	}, {
+		name:              "successfully fits executor-less applications",
+		driverResources:   createResources(1, 3, 0),
+		executorResources: createResources(2, 5, 0),
+		numExecutors:      0,
+		nodesSchedulingMetadata: resources.NodeGroupSchedulingMetadata(map[string]*resources.NodeSchedulingMetadata{
+			"n1": createSchedulingMetadata(5, 25, 6, "zone1"),
+			"n2": createSchedulingMetadata(5, 25, 6, "zone1"),
+		}),
+		nodePriorityOrder:  []string{"n1", "n2"},
+		expectedDriverNode: "n1",
+		willFit:            true,
+	}, {
+		name:              "successfully fits executor-less applications, and accounts for existing reservations",
+		driverResources:   createResources(1, 3, 0),
+		executorResources: createResources(2, 5, 0),
+		numExecutors:      1,
+		nodesSchedulingMetadata: resources.NodeGroupSchedulingMetadata(map[string]*resources.NodeSchedulingMetadata{
+			"n1": createSchedulingMetadata(5, 25, 6, "zone1"),
+			"n2": createSchedulingMetadata(5, 25, 6, "zone1"),
+		}),
+		nodePriorityOrder:  []string{"n1", "n2"},
+		expectedDriverNode: "n1",
+		willFit:            true,
+		expectedCounts:     map[string]int{"n1": 1},
+	}, {
+		name:              "executors fit on a single node",
+		driverResources:   createResources(1, 3, 0),
+		executorResources: createResources(2, 5, 0),
+		numExecutors:      5,
+		nodesSchedulingMetadata: resources.NodeGroupSchedulingMetadata(map[string]*resources.NodeSchedulingMetadata{
+			"n1": createSchedulingMetadata(10, 25, 6, "zone1"),
+			"n2": createSchedulingMetadata(5, 25, 6, "zone1"),
+			"n3": createSchedulingMetadata(20, 25, 6, "zone1"),
+		}),
+		nodePriorityOrder:  []string{"n1", "n2", "n3"},
+		expectedDriverNode: "n1",
+		willFit:            true,
+		expectedCounts:     map[string]int{"n3": 5},
+	}, {
+		name:              "executors fit on the smallest nodes that can accommodate all of them",
+		driverResources:   createResources(1, 3, 0),
+		executorResources: createResources(2, 5, 0),
+		numExecutors:      5,
+		nodesSchedulingMetadata: resources.NodeGroupSchedulingMetadata(map[string]*resources.NodeSchedulingMetadata{
+			"n1": createSchedulingMetadata(200, 500, 6, "zone1"),
+			"n2": createSchedulingMetadata(100, 250, 6, "zone1"),
+		}),
+		nodePriorityOrder:  []string{"n1", "n2", "n3"},
+		expectedDriverNode: "n1",
+		willFit:            true,
+		expectedCounts:     map[string]int{"n2": 5},
+	}, {
+		name:              "when available resources are equal, prefer nodes according to the requested priorities",
+		driverResources:   createResources(1, 3, 0),
+		executorResources: createResources(2, 5, 0),
+		numExecutors:      5,
+		nodesSchedulingMetadata: resources.NodeGroupSchedulingMetadata(map[string]*resources.NodeSchedulingMetadata{
+			"n1": createSchedulingMetadata(10, 25, 6, "zone1"),
+			"n2": createSchedulingMetadata(5, 25, 6, "zone1"),
+			"n3": createSchedulingMetadata(20, 25, 6, "zone1"),
+			"n4": createSchedulingMetadata(20, 25, 6, "zone1"),
+			"n5": createSchedulingMetadata(20, 25, 6, "zone1"),
+		}),
+		nodePriorityOrder:  []string{"n1", "n2", "n3", "n4", "n5"},
+		expectedDriverNode: "n1",
+		willFit:            true,
+		expectedCounts:     map[string]int{"n3": 5},
+	}, {
+		name:              "picks the smallest node that fits the remaining executors",
+		driverResources:   createResources(1, 3, 0),
+		executorResources: createResources(2, 5, 0),
+		numExecutors:      5,
+		nodesSchedulingMetadata: resources.NodeGroupSchedulingMetadata(map[string]*resources.NodeSchedulingMetadata{
+			"n1": createSchedulingMetadata(6, 30, 6, "zone1"),
+			"n2": createSchedulingMetadata(3, 30, 6, "zone1"),
+			"n3": createSchedulingMetadata(8, 30, 6, "zone1"),
+		}),
+		nodePriorityOrder:  []string{"n1", "n2", "n3"},
+		expectedDriverNode: "n1",
+		willFit:            true,
+		expectedCounts:     map[string]int{"n2": 1, "n3": 4},
+	}, {
+		name:              "driver memory does not fit",
+		driverResources:   createResources(2, 4, 1),
+		executorResources: createResources(1, 1, 0),
+		numExecutors:      1,
+		nodesSchedulingMetadata: resources.NodeGroupSchedulingMetadata(map[string]*resources.NodeSchedulingMetadata{
+			"n1": createSchedulingMetadata(2, 3, 1, "zone1"),
+		}),
+		nodePriorityOrder: []string{"n1"},
+		willFit:           false,
+	}, {
+		name:              "application perfectly fits",
+		driverResources:   createResources(1, 2, 1),
+		executorResources: createResources(1, 1, 1),
+		numExecutors:      40,
+		nodesSchedulingMetadata: resources.NodeGroupSchedulingMetadata(map[string]*resources.NodeSchedulingMetadata{
+			"n1": createSchedulingMetadata(13, 14, 13, "zone1"),
+			"n2": createSchedulingMetadata(12, 12, 12, "zone1"),
+			"n3": createSchedulingMetadata(16, 16, 16, "zone1"),
+		}),
+		nodePriorityOrder:  []string{"n1", "n2", "n3"},
+		expectedDriverNode: "n1",
+		willFit:            true,
+		expectedCounts:     map[string]int{"n1": 12, "n2": 12, "n3": 16},
+	}, {
+		name:              "executor cpu do not fit",
+		driverResources:   createResources(1, 1, 0),
+		executorResources: createResources(1, 2, 1),
+		numExecutors:      8,
+		nodesSchedulingMetadata: resources.NodeGroupSchedulingMetadata(map[string]*resources.NodeSchedulingMetadata{
+			"n1": createSchedulingMetadata(8, 20, 8, "zone1"),
+		}),
+		nodePriorityOrder: []string{"n1"},
+		willFit:           false,
+	}, {
+		name:              "Fits when cluster has more nodes than executors",
+		driverResources:   createResources(1, 2, 1),
+		executorResources: createResources(2, 3, 2),
+		numExecutors:      2,
+		nodesSchedulingMetadata: resources.NodeGroupSchedulingMetadata(map[string]*resources.NodeSchedulingMetadata{
+			"n1": createSchedulingMetadata(8, 20, 8, "zone1"),
+			"n2": createSchedulingMetadata(8, 20, 8, "zone1"),
+			"n3": createSchedulingMetadata(8, 20, 8, "zone1"),
+		}),
+		nodePriorityOrder:  []string{"n1", "n2", "n3"},
+		expectedDriverNode: "n1",
+		willFit:            true,
+	}, {
+		name:              "executor gpu does not fit",
+		driverResources:   createResources(1, 1, 1),
+		executorResources: createResources(1, 1, 1),
+		numExecutors:      4,
+		nodesSchedulingMetadata: resources.NodeGroupSchedulingMetadata(map[string]*resources.NodeSchedulingMetadata{
+			"n1_z1": createSchedulingMetadata(4, 4, 4, "z1"),
+			"n1_z2": createSchedulingMetadata(128, 128, 0, "z2"),
+		}),
+		nodePriorityOrder:  []string{"n1_z1", "n1_z2"},
+		expectedDriverNode: "n1_z1",
+		willFit:            false,
+	},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			driver, executors, ok := MinimalFragmentation(
+				context.Background(),
+				test.driverResources,
+				test.executorResources,
+				test.numExecutors,
+				test.nodePriorityOrder,
+				test.nodePriorityOrder,
+				test.nodesSchedulingMetadata)
+			if ok != test.willFit {
+				t.Fatalf("mismatch in willFit, expected: %v, got: %v", test.willFit, ok)
+			}
+			if !test.willFit {
+				return
+			}
+			if driver != test.expectedDriverNode {
+				t.Fatalf("mismatch in driver node, expected: %v, got: %v", test.expectedDriverNode, driver)
+			}
+			resultCounts := map[string]int{}
+			for _, node := range executors {
+				resultCounts[node]++
+			}
+			if test.expectedCounts != nil && !reflect.DeepEqual(resultCounts, test.expectedCounts) {
+				t.Fatalf("executor nodes are not equal, expected: %v, got: %v", test.expectedCounts, resultCounts)
+			}
+		})
+	}
+}

--- a/pkg/binpack/minimal_fragmentation_test.go
+++ b/pkg/binpack/minimal_fragmentation_test.go
@@ -16,6 +16,7 @@ package binpack
 
 import (
 	"context"
+	"math"
 	"reflect"
 	"testing"
 
@@ -28,6 +29,29 @@ func TestMin(t *testing.T) {
 	assert.Equal(t, 1, min(1, 2, 3))
 	assert.Equal(t, 1, min(2, 1, 3))
 	assert.Equal(t, 1, min(2, 3, 1))
+}
+
+func TestGetCapacityAgainstSingleDimension(t *testing.T) {
+	assert.Equal(t, math.MaxInt, getCapacityAgainstSingleDimension(
+		*resource.NewQuantity(2, resource.DecimalSI),
+		*resource.NewQuantity(1, resource.DecimalSI),
+		*resource.NewQuantity(0, resource.DecimalSI),
+	))
+	assert.Equal(t, 2, getCapacityAgainstSingleDimension(
+		*resource.NewQuantity(2, resource.DecimalSI),
+		*resource.NewQuantity(0, resource.DecimalSI),
+		*resource.NewQuantity(1, resource.DecimalSI),
+	))
+	assert.Equal(t, 1, getCapacityAgainstSingleDimension(
+		*resource.NewQuantity(3, resource.DecimalSI),
+		*resource.NewQuantity(1, resource.DecimalSI),
+		*resource.NewQuantity(2, resource.DecimalSI),
+	))
+	assert.Equal(t, 0, getCapacityAgainstSingleDimension(
+		*resource.NewQuantity(2, resource.DecimalSI),
+		*resource.NewQuantity(3, resource.DecimalSI),
+		*resource.NewQuantity(1, resource.DecimalSI),
+	))
 }
 
 func TestGetNodeCapacity(t *testing.T) {

--- a/pkg/binpack/single_az.go
+++ b/pkg/binpack/single_az.go
@@ -1,0 +1,59 @@
+// Copyright (c) 2019 Palantir Technologies. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package binpack
+
+import (
+	"context"
+
+	"github.com/palantir/k8s-spark-scheduler-lib/pkg/resources"
+)
+
+func getSingleAZSparkBinFunction(fn GenericBinPackFunction) SparkBinPackFunction {
+	return SparkBinPackFunction(func(
+		ctx context.Context,
+		driverResources, executorResources *resources.Resources,
+		executorCount int,
+		driverNodePriorityOrder, executorNodePriorityOrder []string,
+		nodesSchedulingMetadata resources.NodeGroupSchedulingMetadata) (string, []string, bool) {
+
+		driverNodePriorityOrderByZone := groupNodesByZone(driverNodePriorityOrder, nodesSchedulingMetadata)
+		executorNodePriorityOrderByZone := groupNodesByZone(executorNodePriorityOrder, nodesSchedulingMetadata)
+
+		for zone, driverNodePriorityOrderForZone := range driverNodePriorityOrderByZone {
+			executorNodePriorityOrderForZone, ok := executorNodePriorityOrderByZone[zone]
+			if !ok {
+				continue
+			}
+			driverNode, executorNodes, hasCapacity := SparkBinPack(ctx, driverResources, executorResources, executorCount, driverNodePriorityOrderForZone, executorNodePriorityOrderForZone, nodesSchedulingMetadata, fn)
+			if hasCapacity {
+				return driverNode, executorNodes, hasCapacity
+			}
+		}
+		return "", nil, false
+	})
+}
+
+func groupNodesByZone(nodeNames []string, nodesSchedulingMetadata resources.NodeGroupSchedulingMetadata) map[string][]string {
+	nodeNamesByZone := make(map[string][]string)
+	for _, nodeName := range nodeNames {
+		nodesSchedulingMetadata, ok := nodesSchedulingMetadata[nodeName]
+		if !ok {
+			continue
+		}
+		zoneLabel := nodesSchedulingMetadata.ZoneLabel
+		nodeNamesByZone[zoneLabel] = append(nodeNamesByZone[zoneLabel], nodeName)
+	}
+	return nodeNamesByZone
+}

--- a/pkg/binpack/single_az_minimal_fragmentation.go
+++ b/pkg/binpack/single_az_minimal_fragmentation.go
@@ -14,8 +14,7 @@
 
 package binpack
 
-// SingleAZTightlyPack is a SparkBinPackFunction that tries to put the driver pod
-// to as prior nodes as possible before trying to tightly pack executors
-// while also ensuring that we can fit everything in a single AZ.
-// If it cannot fit into a single AZ binpacking fails
-var SingleAZTightlyPack = getSingleAZSparkBinFunction(tightlyPackExecutors)
+// SingleAZMinimalFragmentation attempts to use as few nodes as possible to schedule executors
+// when multiple nodes can be used to fit n executors, it will pick the node with the least available resources
+// that still fit n executors, if there are multiple, it will prefer the higher priority node
+var SingleAZMinimalFragmentation = getSingleAZSparkBinFunction(minimalFragmentation)


### PR DESCRIPTION
SingleAZMinimalFragmentation attempts to use as few nodes as possible to schedule executors, thus reducing fragmentation.

Ideally, we can fit all the executors on a single node, if that's the case we pick the host with the fewest available resource that still fits all the executors (breaking ties by looking at the requested node priority order). If the executors require multiple nodes to fit, we first schedule as many executors as possible on the node with the most available resources (breaking ties on node priority order again), and we go back to the first step of the algorithm to schedule the remaining executors.

There are two ideas motivating trying this out:
* having fewer spark applications on a single node means that more pods will finish at the same time, making it easier to scale down said node.
* when a node disappear (spot preemption, unexpected failure, scale down), lost work might need to be recomputed. When losing a single executor it might mean that all the other executors will need to remain idle while previously computed tasks are being be recomputed. If true, then it's probably better to lose multiple executors from a few apps, rather than lose few executors from multiple apps.

One possible downside, aside from less efficient resource utilization overall, is that spreading executors across nodes can be beneficial for some applications that requires a lot of disk space; effectively, this new strategy will colocate nodes onto fewer hosts, thus potentially limiting how much disk can be used for shuffling. This could/should probably be addressed through other mechanism (e.g. actually considering disk needs when scheduling, and/or making use of external shuffle).